### PR TITLE
Fix arbitrary instances

### DIFF
--- a/src/Data/BCP47/Internal/Arbitrary.hs
+++ b/src/Data/BCP47/Internal/Arbitrary.hs
@@ -1,0 +1,38 @@
+module Data.BCP47.Internal.Arbitrary
+  ( Arbitrary
+  , arbitrary
+  , alphaString
+  , alphaNumString
+  , alphaChar
+  , numChar
+  , choose
+  , oneof
+  , suchThat
+  ) where
+
+import Test.QuickCheck
+  (Arbitrary, Gen, arbitrary, choose, elements, oneof, suchThat, vectorOf)
+
+numChar :: Gen Char
+numChar = elements numChars
+
+alphaNumString :: Int -> Gen String
+alphaNumString n = vectorOf n alphaNumChar
+
+alphaString :: Int -> Gen String
+alphaString n = vectorOf n alphaChar
+
+alphaNumChar :: Gen Char
+alphaNumChar = elements alphaNumChars
+
+alphaChar :: Gen Char
+alphaChar = elements alphaChars
+
+alphaNumChars :: String
+alphaNumChars = alphaChars ++ numChars
+
+alphaChars :: String
+alphaChars = ['a' .. 'z'] ++ ['A' .. 'Z']
+
+numChars :: String
+numChars = ['0' .. '9']

--- a/src/Data/BCP47/Internal/Extension.hs
+++ b/src/Data/BCP47/Internal/Extension.hs
@@ -9,10 +9,11 @@ module Data.BCP47.Internal.Extension
 where
 
 import Control.Monad (void, when)
+import Data.BCP47.Internal.Arbitrary
+  (Arbitrary, alphaChar, alphaNumString, arbitrary, choose, suchThat)
 import Data.Bifunctor (first)
 import Data.Text (Text, pack)
 import Data.Void (Void)
-import Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
 import Text.Megaparsec (Parsec, count', parse)
 import Text.Megaparsec.Char (alphaNumChar, char)
 import Text.Megaparsec.Error (parseErrorPretty)
@@ -21,7 +22,11 @@ newtype Extension = Extension { extensionToText :: Text }
   deriving (Show, Eq, Ord)
 
 instance Arbitrary Extension where
-  arbitrary = Extension . pack <$> arbitrary
+  arbitrary = do
+    prefix <- alphaChar `suchThat` (`notElem` ['x', 'X'])
+    len <- choose (2,8)
+    chars <- alphaNumString len
+    pure . Extension . pack $ prefix : '-' : chars
 
 extensionFromText :: Text -> Either Text Extension
 extensionFromText =

--- a/src/Data/BCP47/Internal/LanguageExtension.hs
+++ b/src/Data/BCP47/Internal/LanguageExtension.hs
@@ -8,11 +8,12 @@ module Data.BCP47.Internal.LanguageExtension
   )
 where
 
-import Control.Monad (void)
+import Control.Monad (replicateM, void)
+import Data.BCP47.Internal.Arbitrary (Arbitrary, alphaString, arbitrary)
 import Data.Bifunctor (first)
+import Data.List (intercalate)
 import Data.Text (Text, pack)
 import Data.Void (Void)
-import Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
 import Text.Megaparsec (Parsec, count, parse)
 import Text.Megaparsec.Char (char, letterChar)
 import Text.Megaparsec.Error (parseErrorPretty)
@@ -21,7 +22,9 @@ newtype LanguageExtension = LanguageExtension { languageExtensionToText :: Text 
   deriving (Show, Eq, Ord)
 
 instance Arbitrary LanguageExtension where
-  arbitrary = LanguageExtension . pack <$> arbitrary
+  arbitrary = do
+    components <- replicateM 3 $ alphaString 3
+    pure . LanguageExtension $ pack $ intercalate "-" components
 
 languageExtensionFromText :: Text -> Either Text LanguageExtension
 languageExtensionFromText = first (pack . parseErrorPretty)

--- a/src/Data/BCP47/Internal/PrivateUse.hs
+++ b/src/Data/BCP47/Internal/PrivateUse.hs
@@ -9,12 +9,13 @@ module Data.BCP47.Internal.PrivateUse
 where
 
 import Control.Monad (void)
+import Data.BCP47.Internal.Arbitrary
+  (Arbitrary, alphaNumString, arbitrary, choose)
 import Data.Bifunctor (first)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text, pack)
 import Data.Void (Void)
-import Test.QuickCheck.Arbitrary
 import Text.Megaparsec (Parsec, count', parse, some)
 import Text.Megaparsec.Char (alphaNumChar, char)
 import Text.Megaparsec.Error (parseErrorPretty)
@@ -23,7 +24,10 @@ newtype PrivateUse = PrivateUse { privateUseToText :: Text }
   deriving (Show, Eq, Ord)
 
 instance Arbitrary PrivateUse where
-  arbitrary = PrivateUse . pack <$> arbitrary
+  arbitrary = do
+    len <- choose (1,8)
+    chars <- alphaNumString len
+    pure . PrivateUse $ pack chars
 
 privateUseFromText :: Text -> Either Text (Set PrivateUse)
 privateUseFromText =

--- a/src/Data/BCP47/Internal/Script.hs
+++ b/src/Data/BCP47/Internal/Script.hs
@@ -8,10 +8,10 @@ module Data.BCP47.Internal.Script
   )
 where
 
+import Data.BCP47.Internal.Arbitrary (Arbitrary, alphaString, arbitrary)
 import Data.Bifunctor (first)
 import Data.Text (Text, pack)
 import Data.Void (Void)
-import Test.QuickCheck.Arbitrary
 import Text.Megaparsec (Parsec, count, parse)
 import Text.Megaparsec.Char (letterChar)
 import Text.Megaparsec.Error (parseErrorPretty)
@@ -20,7 +20,7 @@ newtype Script = Script { scriptToText :: Text }
   deriving (Show, Eq, Ord)
 
 instance Arbitrary Script where
-  arbitrary = Script . pack <$> arbitrary
+  arbitrary = Script . pack <$> alphaString 4
 
 scriptFromText :: Text -> Either Text Script
 scriptFromText =

--- a/tests/Data/BCP47Spec.hs
+++ b/tests/Data/BCP47Spec.hs
@@ -11,19 +11,25 @@ import Data.BCP47.Internal.Variant
 import Data.ISO3166_CountryCodes (CountryCode(CN))
 import Data.LanguageCodes (ISO639_1(ZH))
 import qualified Data.Set as Set
-import Data.Text (unpack)
+import Data.Text (pack, unpack)
 import Test.Hspec
+import Test.QuickCheck (property)
 
 spec :: Spec
-spec = describe "fromText" $ it "parses all components" $ do
-  lng <- either (ioError . userError . unpack) pure
-    $ fromText "zh-abc-def-zxy-Hant-CN-1967-y-extensi-x-private1-private2"
-  language lng `shouldBe` ZH
-  extendedLanguageSubtags lng
-    `shouldBe` Set.singleton (LanguageExtension "abc-def-zxy")
-  script lng `shouldBe` Just (Script "Hant")
-  region lng `shouldBe` Just CN
-  variants lng `shouldBe` Set.singleton (Variant "1967")
-  extensions lng `shouldBe` Set.singleton (Extension "y-extensi")
-  privateUse lng
-    `shouldBe` Set.fromList [PrivateUse "private1", PrivateUse "private2"]
+spec = do
+  describe "fromText" $ it "parses all components" $ do
+    lng <- either (ioError . userError . unpack) pure
+      $ fromText "zh-abc-def-zxy-Hant-CN-1967-y-extensi-x-private1-private2"
+    language lng `shouldBe` ZH
+    extendedLanguageSubtags lng
+      `shouldBe` Set.singleton (LanguageExtension "abc-def-zxy")
+    script lng `shouldBe` Just (Script "Hant")
+    region lng `shouldBe` Just CN
+    variants lng `shouldBe` Set.singleton (Variant "1967")
+    extensions lng `shouldBe` Set.singleton (Extension "y-extensi")
+    privateUse lng
+      `shouldBe` Set.fromList [PrivateUse "private1", PrivateUse "private2"]
+  describe "Arbitrary"
+    . it "can parse arbitrary generated tags"
+    . property
+    $ \tag -> fromText (pack (show tag)) `shouldBe` Right tag


### PR DESCRIPTION
Arbitrary instance were generating garbage. Instead arbitrary instances
should produce valid language tags. That is validated by converting
arbitrary tags to text and parsing them back to the same representation.

Addresses https://github.com/freckle/bcp47/issues/2