### PR TITLE
Fixes and updates for use in our Languages API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,8 @@ references:
 jobs:
   build:
     <<: *stack_build
+    environment:
+      STACK_ARGUMENTS: --no-terminal
   build_8.4.4:
     <<: *stack_build
     environment:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-*.cabal
 .stack-work

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ build:
 
 .PHONY: test
 test:
-	stack build $(STACK_ARGUMENTS) --fast --pedantic --test
+	stack build $(STACK_ARGUMENTS) bcp47 --fast --pedantic --test
+	stack build $(STACK_ARGUMENTS) bcp47-orphans --fast --pedantic --test
 
 .PHONY: lint
 lint:

--- a/bcp47-orphans/bcp47-orphans.cabal
+++ b/bcp47-orphans/bcp47-orphans.cabal
@@ -1,0 +1,75 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.33.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 2748e77da174f71232f27cb4e4b57e2883938f8d823bbef034820a95fc7001ce
+
+name:           bcp47-orphans
+version:        0.1.0.0
+synopsis:       BCP47 orphan instances
+description:    Orphan instances for the BCP47 type
+category:       Orphan Instances
+homepage:       https://github.com/freckle/bcp47#readme
+bug-reports:    https://github.com/freckle/bcp47/issues
+author:         Evan Rutledge Borden
+maintainer:     engineering@freckle.com
+copyright:      2019 Freckle Education
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/freckle/bcp47
+
+library
+  exposed-modules:
+      Data.BCP47.Csv
+      Data.BCP47.Esqueleto
+      Data.BCP47.Hashable
+      Data.BCP47.HttpApiData
+      Data.BCP47.PathPieces
+      Data.BCP47.Persist
+  other-modules:
+      Paths_bcp47_orphans
+  hs-source-dirs:
+      library
+  build-depends:
+      base >=4.7 && <5
+    , bcp47
+    , cassava
+    , errors
+    , esqueleto
+    , hashable
+    , http-api-data
+    , path-pieces
+    , persistent
+    , text
+  default-language: Haskell2010
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Data.BCP47.CsvSpec
+      Data.BCP47.PathPiecesSpec
+      Data.BCP47.PersistSpec
+      Data.BCP47.Roundtrip
+      Paths_bcp47_orphans
+  hs-source-dirs:
+      tests
+  build-depends:
+      QuickCheck
+    , base >=4.7 && <5
+    , bcp47
+    , bcp47-orphans
+    , cassava
+    , hspec
+    , path-pieces
+    , persistent
+  default-language: Haskell2010

--- a/bcp47-orphans/library/Data/BCP47/HttpApiData.hs
+++ b/bcp47-orphans/library/Data/BCP47/HttpApiData.hs
@@ -1,0 +1,14 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Data.BCP47.HttpApiData
+  ()
+where
+
+import Data.BCP47 (BCP47, fromText, toText)
+import Web.HttpApiData (FromHttpApiData(..), ToHttpApiData(..))
+
+instance ToHttpApiData BCP47 where
+  toUrlPiece = toText
+
+instance FromHttpApiData BCP47 where
+  parseUrlPiece = fromText

--- a/bcp47-orphans/package.yaml
+++ b/bcp47-orphans/package.yaml
@@ -24,6 +24,7 @@ library:
   - errors
   - esqueleto
   - hashable
+  - http-api-data
   - path-pieces
   - persistent
   - text

--- a/bcp47/bcp47.cabal
+++ b/bcp47/bcp47.cabal
@@ -1,0 +1,111 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.33.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 7ce0af13e684c6f99cbf6a190a99eff76e6c20c4b7f777cdeb5ddd50df646ad0
+
+name:           bcp47
+version:        0.1.0.0
+synopsis:       Language tags as specified by BCP 47
+description:    /Language tags for use in cases where it is desirable to indicate the/
+                /language used in an information object./
+                .
+                / - /<https://tools.ietf.org/html/bcp47>
+                .
+                This package exposes a language tag data type 'BCP47' and a 'Trie' data
+                structure for collecting and querying information that varies based on
+                language tag.
+                .
+                > import Data.BCP47 (en, enGB, sw)
+                > import Data.BCP47.Trie (Trie, fromList, lookup)
+                >
+                > color :: Trie Text
+                > color = fromList [(en, "color"), (sw, "rangi")]
+                >
+                > main = do
+                >   print $ match en color -- Just "color"
+                >   print $ match enGB color -- Nothing
+                >   print $ lookup enGB color -- Just "color"
+category:       Data, Data Structures
+homepage:       https://github.com/freckle/bcp47#readme
+bug-reports:    https://github.com/freckle/bcp47/issues
+author:         Evan Rutledge Borden
+maintainer:     engineering@freckle.com
+copyright:      2019 Freckle Education
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/freckle/bcp47
+
+library
+  exposed-modules:
+      Data.BCP47
+      Data.BCP47.Internal.Arbitrary
+      Data.BCP47.Internal.Extension
+      Data.BCP47.Internal.Language
+      Data.BCP47.Internal.LanguageExtension
+      Data.BCP47.Internal.Parser
+      Data.BCP47.Internal.PrivateUse
+      Data.BCP47.Internal.Region
+      Data.BCP47.Internal.Script
+      Data.BCP47.Internal.Subtags
+      Data.BCP47.Internal.Variant
+      Data.BCP47.Trie
+      Data.BCP47.Trie.Internal
+  other-modules:
+      Paths_bcp47
+  hs-source-dirs:
+      library
+  build-depends:
+      QuickCheck
+    , aeson
+    , base >=4.7 && <5
+    , containers
+    , country
+    , generic-arbitrary
+    , iso639
+    , megaparsec
+    , text
+  default-language: Haskell2010
+
+test-suite doctest
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Paths_bcp47
+  hs-source-dirs:
+      doctest
+  build-depends:
+      base >=4.7 && <5
+    , doctest
+    , megaparsec
+  default-language: Haskell2010
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Data.BCP47.TrieSpec
+      Data.BCP47Spec
+      Paths_bcp47
+  hs-source-dirs:
+      tests
+  build-depends:
+      QuickCheck
+    , aeson
+    , base >=4.7 && <5
+    , bcp47
+    , containers
+    , country
+    , hspec
+    , iso639
+    , text
+  default-language: Haskell2010

--- a/bcp47/library/Data/BCP47.hs
+++ b/bcp47/library/Data/BCP47.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -82,7 +83,6 @@ where
 
 import Control.Applicative ((<|>))
 import Control.Monad (MonadPlus)
-import Country (Country)
 import Country.Identifier
   (unitedKingdomOfGreatBritainAndNorthernIreland, unitedStatesOfAmerica)
 import Data.Aeson
@@ -122,7 +122,7 @@ data BCP47
   { language :: ISO639_1 -- ^ The language subtag
   , subtags :: Set Subtags
   }
-  deriving (Eq, Ord)
+  deriving stock (Eq, Ord)
 
 instance Arbitrary BCP47 where
   arbitrary = BCP47 <$> elements [EN, ES] <*> specs

--- a/bcp47/library/Data/BCP47.hs
+++ b/bcp47/library/Data/BCP47.hs
@@ -286,10 +286,20 @@ mkLocalized lang locale = BCP47 lang . Set.singleton $ SpecifyRegion locale
 -- Right zh
 --
 fromText :: Text -> Either Text BCP47
-fromText = first (pack . errorBundlePretty) . parse parser "fromText"
+fromText =
+  first (pack . errorBundlePretty) . parse (parser <* hidden eof) "fromText"
+
+-- |
+--
+-- >>> _example $ pack "en;"
+-- Right (en,';')
+--
+_example :: Text -> Either Text (BCP47, Char)
+_example = first (pack . errorBundlePretty) . parse p "example"
+  where p = (,) <$> parser <*> char ';'
 
 parser :: Parsec Void Text BCP47
-parser = BCP47 <$> languageP <*> subtagsP <* hidden eof
+parser = BCP47 <$> languageP <*> subtagsP
  where
   subtagsP = mconcat <$> sequenceA
     [ manyAsSet SpecifyLanguageExtension (try (char '-' *> languageExtensionP))

--- a/bcp47/library/Data/BCP47.hs
+++ b/bcp47/library/Data/BCP47.hs
@@ -26,6 +26,7 @@ module Data.BCP47
   , mkLanguage
   , mkLocalized
   , fromText
+  , parser
   -- * Serialization
   , toText
   -- * Subtags

--- a/bcp47/library/Data/BCP47/Internal/Extension.hs
+++ b/bcp47/library/Data/BCP47/Internal/Extension.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Data.BCP47.Internal.Extension
@@ -27,7 +28,7 @@ import Text.Megaparsec.Error (errorBundlePretty)
 -- that is not part of language identification.
 --
 newtype Extension = Extension { extensionToText :: Text }
-  deriving (Show, Eq, Ord)
+  deriving stock (Show, Eq, Ord)
 
 instance Arbitrary Extension where
   arbitrary = do

--- a/bcp47/library/Data/BCP47/Internal/Extension.hs
+++ b/bcp47/library/Data/BCP47/Internal/Extension.hs
@@ -33,7 +33,7 @@ newtype Extension = Extension { extensionToText :: Text }
 instance Arbitrary Extension where
   arbitrary = do
     prefix <- alphaChar `suchThat` (`notElem` ['x', 'X'])
-    len <- choose (2,8)
+    len <- choose (2, 8)
     chars <- alphaNumString len
     pure . Extension . pack $ prefix : '-' : chars
 

--- a/bcp47/library/Data/BCP47/Internal/LanguageExtension.hs
+++ b/bcp47/library/Data/BCP47/Internal/LanguageExtension.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Data.BCP47.Internal.LanguageExtension
@@ -26,7 +27,7 @@ import Text.Megaparsec.Error (errorBundlePretty)
 -- tagged using an existing primary language subtag.
 --
 newtype LanguageExtension = LanguageExtension { languageExtensionToText :: Text }
-  deriving (Show, Eq, Ord)
+  deriving stock (Show, Eq, Ord)
 
 instance Arbitrary LanguageExtension where
   arbitrary = do

--- a/bcp47/library/Data/BCP47/Internal/Parser.hs
+++ b/bcp47/library/Data/BCP47/Internal/Parser.hs
@@ -6,7 +6,7 @@ import Control.Applicative ((<|>))
 import Control.Monad (void)
 import Data.Text (Text)
 import Data.Void (Void)
-import Text.Megaparsec (Parsec, eof, lookAhead)
+import Text.Megaparsec (Parsec, eof, lookAhead, noneOf)
 import Text.Megaparsec.Char (char)
 
 -- | Ensure a subtag extends to the next '-' or end of input
@@ -19,4 +19,8 @@ import Text.Megaparsec.Char (char)
 -- the legal characters in the next valid subtag.
 --
 complete :: Parsec Void Text a -> Parsec Void Text a
-complete parser = parser <* lookAhead (void (char '-') <|> eof)
+complete parser =
+  parser <* lookAhead (void (char '-') <|> eof <|> void (noneOf tagChars))
+
+tagChars :: String
+tagChars = '-' : ['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9']

--- a/bcp47/library/Data/BCP47/Internal/PrivateUse.hs
+++ b/bcp47/library/Data/BCP47/Internal/PrivateUse.hs
@@ -32,7 +32,7 @@ newtype PrivateUse = PrivateUse { privateUseToText :: Text }
 
 instance Arbitrary PrivateUse where
   arbitrary = do
-    len <- choose (1,8)
+    len <- choose (1, 8)
     chars <- alphaNumString len
     pure . PrivateUse $ pack chars
 

--- a/bcp47/library/Data/BCP47/Internal/PrivateUse.hs
+++ b/bcp47/library/Data/BCP47/Internal/PrivateUse.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Data.BCP47.Internal.PrivateUse
@@ -27,7 +28,7 @@ import Text.Megaparsec.Error (errorBundlePretty)
 -- that are important in a given context by private agreement.
 --
 newtype PrivateUse = PrivateUse { privateUseToText :: Text }
-  deriving (Show, Eq, Ord)
+  deriving stock (Show, Eq, Ord)
 
 instance Arbitrary PrivateUse where
   arbitrary = do

--- a/bcp47/library/Data/BCP47/Internal/Script.hs
+++ b/bcp47/library/Data/BCP47/Internal/Script.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Data.BCP47.Internal.Script
@@ -24,7 +25,7 @@ import Text.Megaparsec.Error (errorBundlePretty)
 -- dialects.
 --
 newtype Script = Script { scriptToText :: Text }
-  deriving (Show, Eq, Ord)
+  deriving stock (Show, Eq, Ord)
 
 instance Arbitrary Script where
   arbitrary = Script . pack <$> alphaString 4

--- a/bcp47/library/Data/BCP47/Internal/Subtags.hs
+++ b/bcp47/library/Data/BCP47/Internal/Subtags.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 module Data.BCP47.Internal.Subtags
   ( Subtags(..)
@@ -22,7 +23,7 @@ data Subtags
   | SpecifyVariant Variant
   | SpecifyExtension Extension
   | SpecifyPrivateUse PrivateUse
-  deriving (Show, Eq, Ord, Generic)
+  deriving stock (Show, Eq, Ord, Generic)
 
 instance Arbitrary Subtags where
   arbitrary = oneof

--- a/bcp47/library/Data/BCP47/Internal/Variant.hs
+++ b/bcp47/library/Data/BCP47/Internal/Variant.hs
@@ -50,15 +50,15 @@ newtype Variant = Variant { variantToText :: Text }
 
 instance Arbitrary Variant where
   arbitrary = oneof [alphaNum, digitPrefixed]
-    where
-      alphaNum = do
-        len <- choose (5,8)
-        chars <- alphaNumString len
-        pure . Variant $ pack chars
-      digitPrefixed = do
-        prefix <- numChar
-        chars <- alphaNumString 3
-        pure . Variant $ pack $ prefix : chars
+   where
+    alphaNum = do
+      len <- choose (5, 8)
+      chars <- alphaNumString len
+      pure . Variant $ pack chars
+    digitPrefixed = do
+      prefix <- numChar
+      chars <- alphaNumString 3
+      pure . Variant $ pack $ prefix : chars
 
 -- | Parse a 'Variant' subtag from 'Text'
 variantFromText :: Text -> Either Text Variant

--- a/bcp47/library/Data/BCP47/Internal/Variant.hs
+++ b/bcp47/library/Data/BCP47/Internal/Variant.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Data.BCP47.Internal.Variant
@@ -45,7 +46,7 @@ variantP =
 -- covered by other available subtags.
 --
 newtype Variant = Variant { variantToText :: Text }
-  deriving (Show, Eq, Ord)
+  deriving stock (Show, Eq, Ord)
 
 instance Arbitrary Variant where
   arbitrary = oneof [alphaNum, digitPrefixed]

--- a/bcp47/library/Data/BCP47/Trie/Internal.hs
+++ b/bcp47/library/Data/BCP47/Trie/Internal.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 module Data.BCP47.Trie.Internal
   ( Trie(..)
@@ -31,7 +32,7 @@ import Test.QuickCheck.Arbitrary
 -- | A trie mapping 'BCP47' tags to values
 newtype Trie a
   = Trie { unLanguage :: Map ISO639_1 (Trie2 a)}
-  deriving (Show, Eq, Ord, Functor, Foldable, Traversable)
+  deriving stock (Show, Eq, Ord, Functor, Foldable, Traversable)
 
 instance Semigroup a => Semigroup (Trie a) where
   x <> y = unionUsing (liftA2 (<>)) x y
@@ -63,7 +64,7 @@ unionUsing :: (Maybe a -> Maybe a -> Maybe a) -> Trie a -> Trie a -> Trie a
 unionUsing f (Trie x) (Trie y) = Trie $ Map.unionWith (union2Using f) x y
 
 data Trie2 a = Trie2 (Maybe a) (Map Subtags (Trie2 a))
-  deriving (Show, Eq, Ord, Functor, Foldable, Traversable)
+  deriving stock (Show, Eq, Ord, Functor, Foldable, Traversable)
 
 instance Semigroup a => Semigroup (Trie2 a) where
   x <> y = union2Using (liftA2 (<>)) x y


### PR DESCRIPTION
- 4e7b147 Updates for newer GHC and --pedantic

  - Remove unused import
  - Use `DerivingStrategies` throughout

- 414f9ab Fix style in touched files

- 3e69807 Add HttpApiData orphans

  To use `BCP47` as a Persist key, we need these instances.

- 21d5f9e Export parser

  It can be useful to parse `BCP47` tags in the context of a larger parser, such
  as parsing the HTTP `Accept-Language` Header, which is formatted as

  ```
  {language}[;q={weight}][,...]
  ```

  Doing this on top of `fromText` is possible, but a bit annoying.

  **NOTE**: I attempted to move this to a `Data.BCP47.Parser`, but the current
  top-level module contains too many lower-level data definitions for that to be
  possible without an import-cycle. To address that, we could move most of
  `Data.BCP47` to `.Internal` modules themselves, and leave `Data.BCP47` as a
  re-export, higher-level interface for the most common usage. This would be a
  Good Thing, IMO, but has been deferred for now.