### PR TITLE
Make the Trie type non empty

### DIFF
--- a/bcp47/library/Data/BCP47/Trie.hs
+++ b/bcp47/library/Data/BCP47/Trie.hs
@@ -12,7 +12,6 @@ module Data.BCP47.Trie
   , elem
   , union
   , unionWith
-  , null
   )
 where
 
@@ -34,7 +33,3 @@ match tag trie = match2 tag =<< Map.lookup (language tag) (unLanguage trie)
 -- | Check if a tag exists in the 'Trie'
 elem :: BCP47 -> Trie a -> Bool
 elem tag = isJust . match tag
-
--- | Check if a 'Trie' is empty
-null :: Trie a -> Bool
-null = Map.null . unLanguage

--- a/bcp47/library/Data/BCP47/Trie.hs
+++ b/bcp47/library/Data/BCP47/Trie.hs
@@ -6,6 +6,7 @@
 module Data.BCP47.Trie
   ( Trie
   , fromList
+  , fromNonEmpty
   , singleton
   , lookup
   , match

--- a/bcp47/library/Data/BCP47/Trie/Internal.hs
+++ b/bcp47/library/Data/BCP47/Trie/Internal.hs
@@ -24,10 +24,13 @@ module Data.BCP47.Trie.Internal
 import Control.Applicative (liftA2, (<|>))
 import Data.BCP47
 import Data.BCP47.Internal.Subtags
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Monoid (Last(Last, getLast))
 import Test.QuickCheck.Arbitrary
+import Test.QuickCheck.Modifiers (NonEmptyList(getNonEmpty))
 
 -- | A trie mapping 'BCP47' tags to values
 newtype Trie a
@@ -37,14 +40,11 @@ newtype Trie a
 instance Semigroup a => Semigroup (Trie a) where
   x <> y = unionUsing (liftA2 (<>)) x y
 
-instance Semigroup a => Monoid (Trie a) where
-  mempty = Trie mempty
-
 instance Arbitrary a => Arbitrary (Trie a) where
-  arbitrary = fromList <$> arbitrary
+  arbitrary = fromList . NE.fromList . getNonEmpty <$> arbitrary
 
 -- | Construct a 'Trie' from a list of tag/value pairs.
-fromList :: [(BCP47, a)] -> Trie a
+fromList :: NonEmpty (BCP47, a) -> Trie a
 fromList = foldr (union . uncurry singleton) (Trie mempty)
 
 -- | Construct a 'Trie' from a single tag/value pair.

--- a/bcp47/library/Data/BCP47/Trie/Internal.hs
+++ b/bcp47/library/Data/BCP47/Trie/Internal.hs
@@ -48,7 +48,7 @@ instance Arbitrary a => Arbitrary (Trie a) where
 fromList :: [(BCP47, a)] -> Maybe (Trie a)
 fromList = fmap fromNonEmpty . NE.nonEmpty
 
--- | Construct a 'Trie' from a list of tag/value pairs.
+-- | Construct a 'Trie' from a non empty list of tag/value pairs.
 fromNonEmpty :: NonEmpty (BCP47, a) -> Trie a
 fromNonEmpty = foldr (union . uncurry singleton) (Trie mempty)
 

--- a/bcp47/library/Data/BCP47/Trie/Internal.hs
+++ b/bcp47/library/Data/BCP47/Trie/Internal.hs
@@ -6,6 +6,7 @@
 module Data.BCP47.Trie.Internal
   ( Trie(..)
   , fromList
+  , fromNonEmpty
   , singleton
   , union
   , unionWith
@@ -41,11 +42,15 @@ instance Semigroup a => Semigroup (Trie a) where
   x <> y = unionUsing (liftA2 (<>)) x y
 
 instance Arbitrary a => Arbitrary (Trie a) where
-  arbitrary = fromList . NE.fromList . getNonEmpty <$> arbitrary
+  arbitrary = fromNonEmpty . NE.fromList . getNonEmpty <$> arbitrary
 
 -- | Construct a 'Trie' from a list of tag/value pairs.
-fromList :: NonEmpty (BCP47, a) -> Trie a
-fromList = foldr (union . uncurry singleton) (Trie mempty)
+fromList :: [(BCP47, a)] -> Maybe (Trie a)
+fromList = fmap fromNonEmpty . NE.nonEmpty
+
+-- | Construct a 'Trie' from a list of tag/value pairs.
+fromNonEmpty :: NonEmpty (BCP47, a) -> Trie a
+fromNonEmpty = foldr (union . uncurry singleton) (Trie mempty)
 
 -- | Construct a 'Trie' from a single tag/value pair.
 singleton :: BCP47 -> a -> Trie a

--- a/bcp47/tests/Data/BCP47/TrieSpec.hs
+++ b/bcp47/tests/Data/BCP47/TrieSpec.hs
@@ -17,8 +17,8 @@ spec :: Spec
 spec = do
   describe "Trie" $ do
     it "has equality" $ property $ \(NonEmpty xs) ->
-      fromList (NE.fromList xs)
-        `shouldBe` (fromList (NE.fromList xs) :: Trie Bool)
+      fromNonEmpty (NE.fromList xs)
+        `shouldBe` (fromNonEmpty (NE.fromList xs) :: Trie Bool)
 
     it "can be ordered"
       $ singleton en "color"
@@ -30,31 +30,31 @@ spec = do
       lookup tag (singleton tag "string") `shouldBe` Just "string"
 
     it "lookups no match" $ do
-      let trie = fromList [(en, "color"), (enGB, "colour")]
+      let trie = fromNonEmpty [(en, "color"), (enGB, "colour")]
       lookup es trie `shouldBe` Nothing
 
     it "lookups no match deeply" $ do
-      let trie = fromList [(enGBTJP, "colour")]
+      let trie = fromNonEmpty [(enGBTJP, "colour")]
       lookup enGB trie `shouldBe` Nothing
 
     it "lookups an exact match" $ do
-      let trie = fromList [(en, "color"), (enGB, "colour")]
+      let trie = fromNonEmpty [(en, "color"), (enGB, "colour")]
       lookup en trie `shouldBe` Just "color"
 
     it "lookups on just language" $ do
-      let trie = fromList [(en, "color"), (es, "colour")]
+      let trie = fromNonEmpty [(en, "color"), (es, "colour")]
       lookup es trie `shouldBe` Just "colour"
 
     it "lookups a deep exact match" $ do
-      let trie = fromList [(enGBTJP, "foo"), (enGB, "colour")]
+      let trie = fromNonEmpty [(enGBTJP, "foo"), (enGB, "colour")]
       lookup enGBTJP trie `shouldBe` Just "foo"
 
     it "lookups a relevant match" $ do
-      let trie = fromList [(en, "color"), (enGB, "colour")]
+      let trie = fromNonEmpty [(en, "color"), (enGB, "colour")]
       lookup enTJP trie `shouldBe` Just "color"
 
     it "lookups a deep relevant match" $ do
-      let trie = fromList [(en, "color"), (enGB, "colour")]
+      let trie = fromNonEmpty [(en, "color"), (enGB, "colour")]
       lookup enGBTJP trie `shouldBe` Just "colour"
 
   describe "match" $ do
@@ -62,29 +62,29 @@ spec = do
       match tag (singleton tag "string") `shouldBe` Just "string"
 
     it "matches no match" $ do
-      let trie = fromList [(en, "color"), (enGB, "colour")]
+      let trie = fromNonEmpty [(en, "color"), (enGB, "colour")]
       match es trie `shouldBe` Nothing
 
     it "matches no match deeply" $ do
-      let trie = fromList [(enGBTJP, "colour")]
+      let trie = fromNonEmpty [(enGBTJP, "colour")]
       match enGB trie `shouldBe` Nothing
 
     it "matches an exact match" $ do
-      let trie = fromList [(en, "color"), (enGB, "colour")]
+      let trie = fromNonEmpty [(en, "color"), (enGB, "colour")]
       match en trie `shouldBe` Just "color"
 
     it "matches on just language" $ do
-      let trie = fromList [(en, "color"), (es, "colour")]
+      let trie = fromNonEmpty [(en, "color"), (es, "colour")]
       match es trie `shouldBe` Just "colour"
 
     it "matches a deep exact match" $ do
-      let trie = fromList [(enGBTJP, "foo"), (enGB, "colour")]
+      let trie = fromNonEmpty [(enGBTJP, "foo"), (enGB, "colour")]
       match enGBTJP trie `shouldBe` Just "foo"
 
     it "matches a relevant match" $ do
-      let trie = fromList [(en, "color"), (enGB, "colour")]
+      let trie = fromNonEmpty [(en, "color"), (enGB, "colour")]
       match enTJP trie `shouldBe` Nothing
 
     it "matches a deep relevant match" $ do
-      let trie = fromList [(en, "color"), (enGB, "colour")]
+      let trie = fromNonEmpty [(en, "color"), (enGB, "colour")]
       match enGBTJP trie `shouldBe` Nothing

--- a/bcp47/tests/Data/BCP47/TrieSpec.hs
+++ b/bcp47/tests/Data/BCP47/TrieSpec.hs
@@ -6,17 +6,14 @@ import Prelude hiding (lookup)
 
 import Data.BCP47
 import Data.BCP47.Trie
-import qualified Data.List.NonEmpty as NE
 import Test.Hspec
 import Test.QuickCheck
-import Test.QuickCheck.Modifiers (NonEmptyList(NonEmpty))
 
 spec :: Spec
 spec = do
   describe "Trie" $ do
-    it "has equality" $ property $ \(NonEmpty xs) ->
-      fromNonEmpty (NE.fromList xs)
-        `shouldBe` (fromNonEmpty (NE.fromList xs) :: Trie Bool)
+    it "has equality" $ property $ \xs ->
+      fromList xs `shouldBe` (fromList xs :: Maybe (Trie Bool))
 
     it "can be ordered"
       $ singleton en "color"

--- a/bcp47/tests/Data/BCP47/TrieSpec.hs
+++ b/bcp47/tests/Data/BCP47/TrieSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedLists #-}
+
 module Data.BCP47.TrieSpec
   ( spec
   ) where
@@ -6,14 +8,17 @@ import Prelude hiding (lookup)
 
 import Data.BCP47
 import Data.BCP47.Trie
+import qualified Data.List.NonEmpty as NE
 import Test.Hspec
 import Test.QuickCheck
+import Test.QuickCheck.Modifiers (NonEmptyList(NonEmpty))
 
 spec :: Spec
 spec = do
   describe "Trie" $ do
-    it "has equality" $ property $ \xs ->
-      fromList xs `shouldBe` (fromList xs :: Trie Bool)
+    it "has equality" $ property $ \(NonEmpty xs) ->
+      fromList (NE.fromList xs)
+        `shouldBe` (fromList (NE.fromList xs) :: Trie Bool)
 
     it "can be ordered"
       $ singleton en "color"

--- a/bcp47/tests/Data/BCP47/TrieSpec.hs
+++ b/bcp47/tests/Data/BCP47/TrieSpec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedLists #-}
-
 module Data.BCP47.TrieSpec
   ( spec
   ) where
@@ -30,31 +28,31 @@ spec = do
       lookup tag (singleton tag "string") `shouldBe` Just "string"
 
     it "lookups no match" $ do
-      let trie = fromNonEmpty [(en, "color"), (enGB, "colour")]
+      let Just trie = fromList [(en, "color"), (enGB, "colour")]
       lookup es trie `shouldBe` Nothing
 
     it "lookups no match deeply" $ do
-      let trie = fromNonEmpty [(enGBTJP, "colour")]
+      let Just trie = fromList [(enGBTJP, "colour")]
       lookup enGB trie `shouldBe` Nothing
 
     it "lookups an exact match" $ do
-      let trie = fromNonEmpty [(en, "color"), (enGB, "colour")]
+      let Just trie = fromList [(en, "color"), (enGB, "colour")]
       lookup en trie `shouldBe` Just "color"
 
     it "lookups on just language" $ do
-      let trie = fromNonEmpty [(en, "color"), (es, "colour")]
+      let Just trie = fromList [(en, "color"), (es, "colour")]
       lookup es trie `shouldBe` Just "colour"
 
     it "lookups a deep exact match" $ do
-      let trie = fromNonEmpty [(enGBTJP, "foo"), (enGB, "colour")]
+      let Just trie = fromList [(enGBTJP, "foo"), (enGB, "colour")]
       lookup enGBTJP trie `shouldBe` Just "foo"
 
     it "lookups a relevant match" $ do
-      let trie = fromNonEmpty [(en, "color"), (enGB, "colour")]
+      let Just trie = fromList [(en, "color"), (enGB, "colour")]
       lookup enTJP trie `shouldBe` Just "color"
 
     it "lookups a deep relevant match" $ do
-      let trie = fromNonEmpty [(en, "color"), (enGB, "colour")]
+      let Just trie = fromList [(en, "color"), (enGB, "colour")]
       lookup enGBTJP trie `shouldBe` Just "colour"
 
   describe "match" $ do
@@ -62,29 +60,29 @@ spec = do
       match tag (singleton tag "string") `shouldBe` Just "string"
 
     it "matches no match" $ do
-      let trie = fromNonEmpty [(en, "color"), (enGB, "colour")]
+      let Just trie = fromList [(en, "color"), (enGB, "colour")]
       match es trie `shouldBe` Nothing
 
     it "matches no match deeply" $ do
-      let trie = fromNonEmpty [(enGBTJP, "colour")]
+      let Just trie = fromList [(enGBTJP, "colour")]
       match enGB trie `shouldBe` Nothing
 
     it "matches an exact match" $ do
-      let trie = fromNonEmpty [(en, "color"), (enGB, "colour")]
+      let Just trie = fromList [(en, "color"), (enGB, "colour")]
       match en trie `shouldBe` Just "color"
 
     it "matches on just language" $ do
-      let trie = fromNonEmpty [(en, "color"), (es, "colour")]
+      let Just trie = fromList [(en, "color"), (es, "colour")]
       match es trie `shouldBe` Just "colour"
 
     it "matches a deep exact match" $ do
-      let trie = fromNonEmpty [(enGBTJP, "foo"), (enGB, "colour")]
+      let Just trie = fromList [(enGBTJP, "foo"), (enGB, "colour")]
       match enGBTJP trie `shouldBe` Just "foo"
 
     it "matches a relevant match" $ do
-      let trie = fromNonEmpty [(en, "color"), (enGB, "colour")]
+      let Just trie = fromList [(en, "color"), (enGB, "colour")]
       match enTJP trie `shouldBe` Nothing
 
     it "matches a deep relevant match" $ do
-      let trie = fromNonEmpty [(en, "color"), (enGB, "colour")]
+      let Just trie = fromList [(en, "color"), (enGB, "colour")]
       match enGBTJP trie `shouldBe` Nothing


### PR DESCRIPTION
Non empty data structures are easier to work with. They can easily be
made "empty" by wrapping them in a `Maybe` and the benefits of being
able to remove empty expectations from the core data structure increase
usability downstream.

The underlying data structure for `Trie` is not `NonEmpty`, so this
invariant must be held by operations over it.