### PR TITLE
Add more clarity to lookup function docs

### DIFF
--- a/bcp47/library/Data/BCP47/Trie.hs
+++ b/bcp47/library/Data/BCP47/Trie.hs
@@ -24,6 +24,14 @@ import qualified Data.Map as Map
 import Data.Maybe (isJust)
 
 -- | Lookup the most relevant item for a tag
+--
+-- "Lookup is used to select the single language tag that best matches the
+-- language priority list for a given request...For example, if the language
+-- range is 'de-ch', a lookup operation can produce content with the tags 'de'
+-- or 'de-CH' but never content with the tag 'de-CH-1996'."
+--
+-- https://tools.ietf.org/html/bcp47#page-2-12
+--
 lookup :: BCP47 -> Trie a -> Maybe a
 lookup tag trie = lookup2 tag =<< Map.lookup (language tag) (unLanguage trie)
 


### PR DESCRIPTION
The difference between `lookup` and `match` was not clearly stated. This
adds more robust docs to `lookup`, paraphrasing and pointing to the
relevant ietf text.