### PR TITLE
Add mapMaybe for Trie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .stack-work
+*.dump-hi

--- a/bcp47/library/Data/BCP47/Trie.hs
+++ b/bcp47/library/Data/BCP47/Trie.hs
@@ -13,6 +13,7 @@ module Data.BCP47.Trie
   , elem
   , union
   , unionWith
+  , mapMaybe
   )
 where
 

--- a/bcp47/library/Data/BCP47/Trie/Internal.hs
+++ b/bcp47/library/Data/BCP47/Trie/Internal.hs
@@ -71,7 +71,7 @@ unionUsing f (Trie x) (Trie y) = Trie $ Map.unionWith (union2Using f) x y
 nullToMaybe :: Map k a -> Maybe (Map k a)
 nullToMaybe m = if Map.null m then Nothing else Just m
 
--- Like `Map.mapMaybe` but returns a `Maybe` because `Trie` should be non-empty 
+-- Like `Map.mapMaybe` but returns a `Maybe` because `Trie` should be non-empty
 mapMaybe :: (a -> Maybe b) -> Trie a -> Maybe (Trie b)
 mapMaybe f (Trie x) = Trie <$> nullToMaybe (Map.mapMaybe (mapMaybe2 f) x)
 

--- a/bcp47/library/Data/BCP47/Trie/Internal.hs
+++ b/bcp47/library/Data/BCP47/Trie/Internal.hs
@@ -9,6 +9,7 @@ module Data.BCP47.Trie.Internal
   , union
   , unionWith
   , unionUsing
+  , mapMaybe
   , Trie2(..)
   , Subtags(..)
   , singleton2
@@ -17,6 +18,7 @@ module Data.BCP47.Trie.Internal
   , union2
   , union2Using
   , fromSubtags
+  , mapMaybe2
   )
   where
 
@@ -66,6 +68,13 @@ unionWith f = unionUsing (liftA2 f)
 unionUsing :: (Maybe a -> Maybe a -> Maybe a) -> Trie a -> Trie a -> Trie a
 unionUsing f (Trie x) (Trie y) = Trie $ Map.unionWith (union2Using f) x y
 
+nullToMaybe :: Map k a -> Maybe (Map k a)
+nullToMaybe m = if Map.null m then Nothing else Just m
+
+-- Like `Map.mapMaybe` but returns a `Maybe` because `Trie` should be non-empty 
+mapMaybe :: (a -> Maybe b) -> Trie a -> Maybe (Trie b)
+mapMaybe f (Trie x) = Trie <$> nullToMaybe (Map.mapMaybe (mapMaybe2 f) x)
+
 data Trie2 a = Trie2 (Maybe a) (Map Subtags (Trie2 a))
   deriving stock (Show, Eq, Ord, Functor, Foldable, Traversable)
 
@@ -74,6 +83,14 @@ instance Semigroup a => Semigroup (Trie2 a) where
 
 instance Monoid a => Monoid (Trie2 a) where
   mempty = Trie2 mempty mempty
+
+mapMaybe2 :: (a -> Maybe b) -> Trie2 a -> Maybe (Trie2 b)
+mapMaybe2 f = go
+ where
+  go (Trie2 x xs) = case (f =<< x, nullToMaybe $ Map.mapMaybe go xs) of
+    (Nothing, Nothing) -> Nothing
+    (Just x', Nothing) -> Just $ Trie2 (Just x') mempty
+    (x', Just xs') -> Just $ Trie2 x' xs'
 
 singleton2 :: BCP47 -> a -> Trie2 a
 singleton2 tag = fromSubtags (toSubtags tag)

--- a/bcp47/tests/Data/BCP47/TrieSpec.hs
+++ b/bcp47/tests/Data/BCP47/TrieSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeApplications #-}
+
 module Data.BCP47.TrieSpec
   ( spec
   ) where
@@ -6,6 +8,7 @@ import Prelude hiding (lookup)
 
 import Data.BCP47
 import Data.BCP47.Trie
+import Data.BCP47.Trie.Internal (mapMaybe)
 import Test.Hspec
 import Test.QuickCheck
 
@@ -19,6 +22,31 @@ spec = do
       $ singleton en "color"
       < singleton es "color"
       `shouldBe` True
+
+    describe "mapMaybe" $ do
+      it "returns Nothing if empty resulting Trie" $ do
+        let
+          (Just given) = fromList [(en, Nothing), (enGB, Nothing)]
+          expected = fromList @String []
+        mapMaybe id given `shouldBe` expected
+
+      it "returns top-level Just" $ do
+        let
+          (Just given) = fromList [(en, Just "color"), (enGB, Nothing)]
+          expected = fromList [(en, "color")]
+        mapMaybe id given `shouldBe` expected
+
+      it "returns leaf Just" $ do
+        let
+          (Just given) = fromList [(en, Nothing), (enGB, Just "colour")]
+          expected = fromList [(enGB, "colour")]
+        mapMaybe id given `shouldBe` expected
+
+      it "returns both leaf and top-level Justs" $ do
+        let
+          (Just given) = fromList [(en, Just "color"), (enGB, Just "colour")]
+          expected = fromList [(en, "color"), (enGB, "colour")]
+        mapMaybe id given `shouldBe` expected
 
   describe "lookup" $ do
     it "should always lookup a path it inserts" $ property $ \tag ->

--- a/bcp47/tests/Data/BCP47/TrieSpec.hs
+++ b/bcp47/tests/Data/BCP47/TrieSpec.hs
@@ -12,6 +12,10 @@ import Data.BCP47.Trie.Internal (mapMaybe)
 import Test.Hspec
 import Test.QuickCheck
 
+
+catMaybes :: Trie (Maybe a) -> Maybe (Trie a)
+catMaybes = mapMaybe id
+
 spec :: Spec
 spec = do
   describe "Trie" $ do
@@ -28,25 +32,25 @@ spec = do
         let
           (Just given) = fromList [(en, Nothing), (enGB, Nothing)]
           expected = fromList @String []
-        mapMaybe id given `shouldBe` expected
+        catMaybes given `shouldBe` expected
 
       it "returns top-level Just" $ do
         let
           (Just given) = fromList [(en, Just "color"), (enGB, Nothing)]
           expected = fromList [(en, "color")]
-        mapMaybe id given `shouldBe` expected
+        catMaybes given `shouldBe` expected
 
       it "returns leaf Just" $ do
         let
           (Just given) = fromList [(en, Nothing), (enGB, Just "colour")]
           expected = fromList [(enGB, "colour")]
-        mapMaybe id given `shouldBe` expected
+        catMaybes given `shouldBe` expected
 
       it "returns both leaf and top-level Justs" $ do
         let
           (Just given) = fromList [(en, Just "color"), (enGB, Just "colour")]
           expected = fromList [(en, "color"), (enGB, "colour")]
-        mapMaybe id given `shouldBe` expected
+        catMaybes given `shouldBe` expected
 
   describe "lookup" $ do
     it "should always lookup a path it inserts" $ property $ \tag ->

--- a/bcp47/tests/Data/BCP47/TrieSpec.hs
+++ b/bcp47/tests/Data/BCP47/TrieSpec.hs
@@ -8,7 +8,6 @@ import Prelude hiding (lookup)
 
 import Data.BCP47
 import Data.BCP47.Trie
-import Data.BCP47.Trie.Internal (mapMaybe)
 import Test.Hspec
 import Test.QuickCheck
 

--- a/bcp47/tests/Data/BCP47/TrieSpec.hs
+++ b/bcp47/tests/Data/BCP47/TrieSpec.hs
@@ -9,7 +9,8 @@ import Prelude hiding (lookup)
 import Data.BCP47
 import Data.BCP47.Trie
 import Data.Foldable
-import qualified Data.Maybe as M
+import qualified Data.List as List
+import qualified Data.Maybe as Maybe
 import Test.Hspec
 import Test.QuickCheck
 
@@ -28,14 +29,14 @@ spec = do
       `shouldBe` True
 
     describe "mapMaybe" $ do
-      it "count of Justs is constant" $ property $ \xs ->
+      it "Justs are constant" $ property $ \xs ->
         let
           trie = fromList xs :: Maybe (Trie (Maybe Bool))
-          expected = do
-            l <- length . M.catMaybes . toList <$> trie
-            if l == 0 then Nothing else Just l
-          actual = length <$> (catMaybes =<< trie)
-        in expected `shouldBe` actual
+          expected = List.sort <$> do
+            m <- Maybe.catMaybes . toList <$> trie
+            if null m then Nothing else Just m
+          actual = List.sort . toList <$> (catMaybes =<< trie)
+        in expected == actual
 
       it "returns Nothing if empty resulting Trie" $ do
         let

--- a/bcp47/tests/Data/BCP47/TrieSpec.hs
+++ b/bcp47/tests/Data/BCP47/TrieSpec.hs
@@ -10,7 +10,8 @@ import Data.BCP47
 import Data.BCP47.Trie
 import Test.Hspec
 import Test.QuickCheck
-
+import Data.Foldable
+import qualified Data.Maybe as M
 
 catMaybes :: Trie (Maybe a) -> Maybe (Trie a)
 catMaybes = mapMaybe id
@@ -27,6 +28,15 @@ spec = do
       `shouldBe` True
 
     describe "mapMaybe" $ do
+      it "count of Justs is constant" $ property $ \xs ->
+        let
+          trie = fromList xs :: Maybe (Trie (Maybe Bool))
+          expected = do
+            l <- length . M.catMaybes . toList <$> trie
+            if l == 0 then Nothing else Just l
+          actual = length <$> (catMaybes =<< trie)
+        in expected `shouldBe` actual
+
       it "returns Nothing if empty resulting Trie" $ do
         let
           (Just given) = fromList [(en, Nothing), (enGB, Nothing)]

--- a/bcp47/tests/Data/BCP47/TrieSpec.hs
+++ b/bcp47/tests/Data/BCP47/TrieSpec.hs
@@ -8,10 +8,10 @@ import Prelude hiding (lookup)
 
 import Data.BCP47
 import Data.BCP47.Trie
-import Test.Hspec
-import Test.QuickCheck
 import Data.Foldable
 import qualified Data.Maybe as M
+import Test.Hspec
+import Test.QuickCheck
 
 catMaybes :: Trie (Maybe a) -> Maybe (Trie a)
 catMaybes = mapMaybe id


### PR DESCRIPTION
I needed a `mapMaybe` like function over `Trie a` when trying to write a function to union two `Trie`s with some default behavior in `text-assets`

This implements `mapMaybe` but with a slight wrinkle in that you ultimately must return a `Maybe (Trie a)` due to the fact that `Trie a` should be non-empty.