### PR TITLE
Prepare next release

### DIFF
--- a/bcp47-orphans/ChangeLog.md
+++ b/bcp47-orphans/ChangeLog.md
@@ -1,3 +1,11 @@
-# Changelog for bcp47-cassava
+## [*Unreleased*](https://github.com/freckle/bcp47/compare/bcp47-orphans-v0.1.0.1...master)
 
-## Unreleased changes
+None
+
+## [v0.1.0.1](https://github.com/freckle/bcp47/compare/bcp47-orphans-v0.1.0.0...bcp47-orphans-v0.1.0.1)
+
+- Instances for `HttpApiData` [#10](https://github.com/freckle/bcp47/pull/10)
+
+## [v0.1.0.0](https://github.com/freckle/bcp47/tree/v0.1.0.0)
+
+First tagged release.

--- a/bcp47-orphans/package.yaml
+++ b/bcp47-orphans/package.yaml
@@ -1,5 +1,5 @@
 name: bcp47-orphans
-version: 0.1.0.0
+version: 0.1.0.1
 github: "freckle/bcp47"
 license: MIT
 author: "Evan Rutledge Borden"

--- a/bcp47/ChangeLog.md
+++ b/bcp47/ChangeLog.md
@@ -1,3 +1,12 @@
-# Changelog for bcp47
+## [*Unreleased*](https://github.com/freckle/bcp47/compare/bcp47-v0.2.0.0...master)
 
-## Unreleased changes
+None
+
+## [v0.2.1.0](https://github.com/freckle/bcp47/compare/bcp47-v0.1.0.0...bcp47-v0.2.0.0)
+
+- Add `mapMaybe` for `Trie` [#16](https://github.com/freckle/bcp47/pull/16)
+- Make `Trie` a non-empty data type [#11](https://github.com/freckle/bcp47/pull/11)
+
+## [v0.1.0.0](https://github.com/freckle/bcp47/tree/v0.1.0.0)
+
+First tagged release.

--- a/bcp47/package.yaml
+++ b/bcp47/package.yaml
@@ -1,5 +1,5 @@
 name: bcp47
-version: 0.1.0.0
+version: 0.2.0.0
 github:  "freckle/bcp47"
 license: MIT
 author: "Evan Rutledge Borden"


### PR DESCRIPTION
Maintains separate Changelogs by package and plans to generate name-prefixed
tags for released versions.

bcp47-orphans gets a Patch bump because it's a new instance. bcp47 gets a Major
bump because because the Trie type has meaningfully changed.