### PR TITLE
Add release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release to Hackage
+
+on:
+  push:
+    tags:
+      - 'bcp47-v*'
+      - 'bcp47-orphans-v*'
+
+jobs:
+  release:
+    strategy:
+      matrix:
+        package:
+          - bcp47
+          - bcp47-orphans
+    runs-on: ubuntu-latest
+    env:
+      HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: freckle/stack-upload-action@main
+        if: ${{ startsWith(github.ref, `${matrix.package}-v`) }}
+        with:
+          working-directory: ${{ matrix.package }}
+          pvp-bounds: both


### PR DESCRIPTION
The idea is to listen to either package's version tag and run a matrix of a job
for package, then only run the upload step with that job if the event tag
matches.