### PR TITLE
Relax `persistent` upper bound

### DIFF
--- a/bcp47-orphans/package.yaml
+++ b/bcp47-orphans/package.yaml
@@ -26,7 +26,7 @@ library:
   - hashable
   - http-api-data
   - path-pieces
-  - persistent < 2.13
+  - persistent < 2.14
   - text
 
 tests:
@@ -40,4 +40,4 @@ tests:
     - cassava
     - hspec
     - path-pieces
-    - persistent < 2.13
+    - persistent < 2.14


### PR DESCRIPTION
Tests pass just fine with this `stack.yaml`:

```
resolver: lts-17.1
packages:
  - bcp47
  - bcp47-orphans
ghc-options:
  "$locals": -fwrite-ide-info

extra-deps:
  - persistent-2.13.0.0
  - esqueleto-3.4.2.1
  - lift-type-0.1.0.1
```

A Hackage revision would allow the current version to work, too.