### PR TITLE
Make BCP47 parsing and Trie lookups case-insensitive

### DIFF
--- a/bcp47/bcp47.cabal
+++ b/bcp47/bcp47.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1e882730e15751e79bdd8bf11849b12900164dc35f245326fce37336340bab15
+-- hash: ab86ef247975da044ef48c4605b4f789d493543d00fcb25dfa630b00abb959a2
 
 name:           bcp47
 version:        0.2.0.4
@@ -68,6 +68,7 @@ library
       QuickCheck
     , aeson
     , base >=4.7 && <5
+    , case-insensitive
     , containers
     , country
     , generic-arbitrary

--- a/bcp47/bcp47.cabal
+++ b/bcp47/bcp47.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ab86ef247975da044ef48c4605b4f789d493543d00fcb25dfa630b00abb959a2
+-- hash: c383153b48e25802f77f220209eafb4f62369caa07a65b48932eb181dc243d8f
 
 name:           bcp47
 version:        0.2.0.4
@@ -49,6 +49,7 @@ library
   exposed-modules:
       Data.BCP47
       Data.BCP47.Internal.Arbitrary
+      Data.BCP47.Internal.CIText
       Data.BCP47.Internal.Extension
       Data.BCP47.Internal.Language
       Data.BCP47.Internal.LanguageExtension

--- a/bcp47/library/Data/BCP47.hs
+++ b/bcp47/library/Data/BCP47.hs
@@ -79,6 +79,8 @@ module Data.BCP47
   , enUS
   , enTJP
   , enGBTJP
+  , enTJPUpper
+  , enGBTJPUpper
   )
 where
 
@@ -98,6 +100,7 @@ import Data.BCP47.Internal.Script
 import Data.BCP47.Internal.Subtags
 import Data.BCP47.Internal.Variant
 import Data.Bifunctor (first)
+import Data.CaseInsensitive (mk, original)
 import Data.Foldable (toList)
 import Data.LanguageCodes (ISO639_1(EN, ES, SW))
 import qualified Data.List as List
@@ -165,15 +168,15 @@ toText b = T.intercalate "-" $ mconcat
   [ [languageToText $ language b]
   , mapMaybe fromSubtags . Set.toList $ subtags b
   , if Set.null (privateUse b) then [] else ["x"]
-  , map privateUseToText . Set.toList $ privateUse b
+  , map (original . privateUseToText) . Set.toList $ privateUse b
   ]
  where
   fromSubtags = \case
-    SpecifyLanguageExtension x -> Just $ languageExtensionToText x
-    SpecifyScript x -> Just $ scriptToText x
+    SpecifyLanguageExtension x -> Just $ original $ languageExtensionToText x
+    SpecifyScript x -> Just $ original $ scriptToText x
     SpecifyRegion x -> Just $ regionToText x
-    SpecifyVariant x -> Just $ variantToText x
-    SpecifyExtension x -> Just $ extensionToText x
+    SpecifyVariant x -> Just $ original $ variantToText x
+    SpecifyExtension x -> Just $ original $ extensionToText x
     SpecifyPrivateUse _ -> Nothing
 
 -- | Look up all language extension subtags
@@ -338,13 +341,27 @@ enUS = mkLocalized EN unitedStatesOfAmerica
 -- | A nonsense tag @en-t-jp@
 enTJP :: BCP47
 enTJP = en
-  { subtags = Set.insert (SpecifyExtension (Extension (pack "t-jp")))
+  { subtags = Set.insert (SpecifyExtension (Extension (mk (pack "t-jp"))))
+    $ subtags en
+  }
+
+-- | A nonsense tag @en-T-jp@
+enTJPUpper :: BCP47
+enTJPUpper = en
+  { subtags = Set.insert (SpecifyExtension (Extension (mk (pack "T-jp"))))
     $ subtags en
   }
 
 -- | A nonsense tag @en-GB-t-jp@
 enGBTJP :: BCP47
 enGBTJP = enGB
-  { subtags = Set.insert (SpecifyExtension (Extension (pack "t-jp")))
+  { subtags = Set.insert (SpecifyExtension (Extension (mk (pack "t-jp"))))
+    $ subtags enGB
+  }
+
+-- | A nonsense tag @en-GB-t-jp@
+enGBTJPUpper :: BCP47
+enGBTJPUpper = enGB
+  { subtags = Set.insert (SpecifyExtension (Extension (mk (pack "T-jp"))))
     $ subtags enGB
   }

--- a/bcp47/library/Data/BCP47.hs
+++ b/bcp47/library/Data/BCP47.hs
@@ -100,7 +100,6 @@ import Data.BCP47.Internal.Script
 import Data.BCP47.Internal.Subtags
 import Data.BCP47.Internal.Variant
 import Data.Bifunctor (first)
-import Data.CaseInsensitive (mk, original)
 import Data.Foldable (toList)
 import Data.LanguageCodes (ISO639_1(EN, ES, SW))
 import qualified Data.List as List
@@ -168,15 +167,15 @@ toText b = T.intercalate "-" $ mconcat
   [ [languageToText $ language b]
   , mapMaybe fromSubtags . Set.toList $ subtags b
   , if Set.null (privateUse b) then [] else ["x"]
-  , map (original . privateUseToText) . Set.toList $ privateUse b
+  , map privateUseToText . Set.toList $ privateUse b
   ]
  where
   fromSubtags = \case
-    SpecifyLanguageExtension x -> Just $ original $ languageExtensionToText x
-    SpecifyScript x -> Just $ original $ scriptToText x
+    SpecifyLanguageExtension x -> Just $ languageExtensionToText x
+    SpecifyScript x -> Just $ scriptToText x
     SpecifyRegion x -> Just $ regionToText x
-    SpecifyVariant x -> Just $ original $ variantToText x
-    SpecifyExtension x -> Just $ original $ extensionToText x
+    SpecifyVariant x -> Just $ variantToText x
+    SpecifyExtension x -> Just $ extensionToText x
     SpecifyPrivateUse _ -> Nothing
 
 -- | Look up all language extension subtags
@@ -341,27 +340,27 @@ enUS = mkLocalized EN unitedStatesOfAmerica
 -- | A nonsense tag @en-t-jp@
 enTJP :: BCP47
 enTJP = en
-  { subtags = Set.insert (SpecifyExtension (Extension (mk (pack "t-jp"))))
+  { subtags = Set.insert (SpecifyExtension (Extension "t-jp"))
     $ subtags en
   }
 
 -- | A nonsense tag @en-T-jp@
 enTJPUpper :: BCP47
 enTJPUpper = en
-  { subtags = Set.insert (SpecifyExtension (Extension (mk (pack "T-jp"))))
+  { subtags = Set.insert (SpecifyExtension (Extension "T-jp"))
     $ subtags en
   }
 
 -- | A nonsense tag @en-GB-t-jp@
 enGBTJP :: BCP47
 enGBTJP = enGB
-  { subtags = Set.insert (SpecifyExtension (Extension (mk (pack "t-jp"))))
+  { subtags = Set.insert (SpecifyExtension (Extension "t-jp"))
     $ subtags enGB
   }
 
 -- | A nonsense tag @en-GB-t-jp@
 enGBTJPUpper :: BCP47
 enGBTJPUpper = enGB
-  { subtags = Set.insert (SpecifyExtension (Extension (mk (pack "T-jp"))))
+  { subtags = Set.insert (SpecifyExtension (Extension "T-jp"))
     $ subtags enGB
   }

--- a/bcp47/library/Data/BCP47/Internal/CIText.hs
+++ b/bcp47/library/Data/BCP47/Internal/CIText.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module Data.BCP47.Internal.CIText
+  ( CIText(..)
+  , fromText
+  , pack
+  , original
+  , foldedCase
+  ) where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.CaseInsensitive (CI)
+import Data.String (IsString)
+import qualified Data.CaseInsensitive as CI
+
+-- | Internal newtype for 'CI Text'
+--
+-- Constructor is exposed since this is an internal module, but ths
+-- interface may change. Module is meant to be imported qualified.
+--
+newtype CIText = CIText
+  { unCIText :: CI Text
+  }
+  deriving newtype (Eq, Show, Ord, IsString)
+
+-- | Convert 'Text' to 'CIText'
+fromText :: Text -> CIText
+fromText = CIText . CI.mk
+
+-- | Convert 'String' to 'CIText'
+pack :: String -> CIText
+pack = fromText . T.pack
+
+-- | Extract case-folded 'Text'
+foldedCase :: CIText -> Text
+foldedCase = CI.foldedCase . unCIText
+
+-- | Recover original 'Text'
+original :: CIText -> Text
+original = CI.original . unCIText

--- a/bcp47/library/Data/BCP47/Internal/Extension.hs
+++ b/bcp47/library/Data/BCP47/Internal/Extension.hs
@@ -12,12 +12,12 @@ where
 import Control.Monad (void, when)
 import Data.BCP47.Internal.Arbitrary
   (Arbitrary, alphaChar, alphaNumString, arbitrary, choose, suchThat)
-import Data.BCP47.Internal.Parser (complete)
+import Data.BCP47.Internal.Parser (complete, asciiLetterDigit)
 import Data.Bifunctor (first)
 import Data.Text (Text, pack)
 import Data.Void (Void)
 import Text.Megaparsec (Parsec, count', parse)
-import Text.Megaparsec.Char (alphaNumChar, char)
+import Text.Megaparsec.Char (char)
 import Text.Megaparsec.Error (errorBundlePretty)
 
 -- | Extension subtags
@@ -58,8 +58,8 @@ extensionFromText =
 --
 extensionP :: Parsec Void Text Extension
 extensionP = complete $ do
-  ext <- alphaNumChar
+  ext <- asciiLetterDigit
   when (ext `elem` ['x', 'X']) $ fail "private use suffix found"
   void $ char '-'
-  rest <- count' 2 8 alphaNumChar
+  rest <- count' 2 8 asciiLetterDigit
   pure . Extension . pack $ ext : '-' : rest

--- a/bcp47/library/Data/BCP47/Internal/Extension.hs
+++ b/bcp47/library/Data/BCP47/Internal/Extension.hs
@@ -14,6 +14,7 @@ import Data.BCP47.Internal.Arbitrary
   (Arbitrary, alphaChar, alphaNumString, arbitrary, choose, suchThat)
 import Data.BCP47.Internal.Parser (complete, asciiLetterDigit)
 import Data.Bifunctor (first)
+import Data.CaseInsensitive (CI, mk)
 import Data.Text (Text, pack)
 import Data.Void (Void)
 import Text.Megaparsec (Parsec, count', parse)
@@ -27,7 +28,7 @@ import Text.Megaparsec.Error (errorBundlePretty)
 -- is commonly used in association with languages or language tags but
 -- that is not part of language identification.
 --
-newtype Extension = Extension { extensionToText :: Text }
+newtype Extension = Extension { extensionToText :: CI Text }
   deriving stock (Show, Eq, Ord)
 
 instance Arbitrary Extension where
@@ -35,7 +36,7 @@ instance Arbitrary Extension where
     prefix <- alphaChar `suchThat` (`notElem` ['x', 'X'])
     len <- choose (2, 8)
     chars <- alphaNumString len
-    pure . Extension . pack $ prefix : '-' : chars
+    pure . Extension . mk . pack $ prefix : '-' : chars
 
 -- | Parse an 'Extension' subtag from 'Text'
 extensionFromText :: Text -> Either Text Extension
@@ -62,4 +63,4 @@ extensionP = complete $ do
   when (ext `elem` ['x', 'X']) $ fail "private use suffix found"
   void $ char '-'
   rest <- count' 2 8 asciiLetterDigit
-  pure . Extension . pack $ ext : '-' : rest
+  pure . Extension . mk . pack $ ext : '-' : rest

--- a/bcp47/library/Data/BCP47/Internal/Language.hs
+++ b/bcp47/library/Data/BCP47/Internal/Language.hs
@@ -8,13 +8,12 @@ module Data.BCP47.Internal.Language
   )
 where
 
-import Data.BCP47.Internal.Parser (complete)
+import Data.BCP47.Internal.Parser (complete, asciiLetter)
 import Data.Bifunctor (first)
 import Data.LanguageCodes (ISO639_1, fromChars)
 import Data.Text (Text, pack, toLower)
 import Data.Void (Void)
 import Text.Megaparsec (Parsec, parse)
-import Text.Megaparsec.Char (lowerChar)
 import Text.Megaparsec.Error (errorBundlePretty)
 
 languageToText :: ISO639_1 -> Text
@@ -39,5 +38,5 @@ languageFromText =
 --
 languageP :: Parsec Void Text ISO639_1
 languageP = complete $ do
-  mCode <- fromChars <$> lowerChar <*> lowerChar
+  mCode <- fromChars <$> asciiLetter <*> asciiLetter
   maybe (fail "unknown ISO-639-1 code") pure mCode

--- a/bcp47/library/Data/BCP47/Internal/LanguageExtension.hs
+++ b/bcp47/library/Data/BCP47/Internal/LanguageExtension.hs
@@ -13,6 +13,7 @@ import Control.Monad (replicateM, void)
 import Data.BCP47.Internal.Arbitrary (Arbitrary, alphaString, arbitrary)
 import Data.BCP47.Internal.Parser (complete, asciiLetter)
 import Data.Bifunctor (first)
+import Data.CaseInsensitive (CI, mk)
 import Data.List (intercalate)
 import Data.Text (Text, pack)
 import Data.Void (Void)
@@ -26,13 +27,13 @@ import Text.Megaparsec.Error (errorBundlePretty)
 -- various historical and compatibility reasons, are closely identified with or
 -- tagged using an existing primary language subtag.
 --
-newtype LanguageExtension = LanguageExtension { languageExtensionToText :: Text }
+newtype LanguageExtension = LanguageExtension { languageExtensionToText :: CI Text }
   deriving stock (Show, Eq, Ord)
 
 instance Arbitrary LanguageExtension where
   arbitrary = do
     components <- replicateM 3 $ alphaString 3
-    pure . LanguageExtension $ pack $ intercalate "-" components
+    pure $ LanguageExtension $ mk $ pack $ intercalate "-" components
 
 -- | Parse a 'LanguageExtension' subtag from 'Text'
 languageExtensionFromText :: Text -> Either Text LanguageExtension
@@ -55,5 +56,5 @@ languageExtensionP = complete $ do
   c1 <- count 3 asciiLetter
   void $ char '-'
   c2 <- count 3 asciiLetter
-  let ext = pack $ mconcat [iso639, "-", c1, "-", c2]
+  let ext = mk $ pack $ mconcat [iso639, "-", c1, "-", c2]
   pure $ LanguageExtension ext

--- a/bcp47/library/Data/BCP47/Internal/LanguageExtension.hs
+++ b/bcp47/library/Data/BCP47/Internal/LanguageExtension.hs
@@ -11,13 +11,13 @@ where
 
 import Control.Monad (replicateM, void)
 import Data.BCP47.Internal.Arbitrary (Arbitrary, alphaString, arbitrary)
-import Data.BCP47.Internal.Parser (complete)
+import Data.BCP47.Internal.Parser (complete, asciiLetter)
 import Data.Bifunctor (first)
 import Data.List (intercalate)
 import Data.Text (Text, pack)
 import Data.Void (Void)
 import Text.Megaparsec (Parsec, count, parse)
-import Text.Megaparsec.Char (char, letterChar)
+import Text.Megaparsec.Char (char)
 import Text.Megaparsec.Error (errorBundlePretty)
 
 -- | Extended language subtags
@@ -50,10 +50,10 @@ languageExtensionFromText = first (pack . errorBundlePretty)
 --
 languageExtensionP :: Parsec Void Text LanguageExtension
 languageExtensionP = complete $ do
-  iso639 <- count 3 letterChar
+  iso639 <- count 3 asciiLetter
   void $ char '-'
-  c1 <- count 3 letterChar
+  c1 <- count 3 asciiLetter
   void $ char '-'
-  c2 <- count 3 letterChar
+  c2 <- count 3 asciiLetter
   let ext = pack $ mconcat [iso639, "-", c1, "-", c2]
   pure $ LanguageExtension ext

--- a/bcp47/library/Data/BCP47/Internal/Parser.hs
+++ b/bcp47/library/Data/BCP47/Internal/Parser.hs
@@ -1,12 +1,16 @@
 module Data.BCP47.Internal.Parser
   ( complete
+  , asciiLetterDigit
+  , asciiLetter
+  , asciiDigit
   ) where
 
 import Control.Applicative ((<|>))
 import Control.Monad (void)
 import Data.Text (Text)
+import Data.Char (ord)
 import Data.Void (Void)
-import Text.Megaparsec (Parsec, eof, lookAhead, noneOf)
+import Text.Megaparsec (Parsec, eof, lookAhead, noneOf, satisfy, (<?>))
 import Text.Megaparsec.Char (char)
 
 -- | Ensure a subtag extends to the next '-' or end of input
@@ -24,3 +28,39 @@ complete parser =
 
 tagChars :: String
 tagChars = '-' : ['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9']
+{-# NOINLINE tagChars #-}
+
+-- | Parse a single case-insensitive ASCII letter or digit
+asciiLetterDigit :: Parsec Void Text Char
+asciiLetterDigit = satisfy isAsciiLetterDigit <?> "ascii letter or digit"
+ where
+  isAsciiLetterDigit c = do
+    let code = ord c
+    isCodeAsciiUpper code || isCodeAsciiLower code || isCodeAsciiDigit code
+{-# INLINE asciiLetterDigit #-}
+
+-- | Parse a single case-insensitive ASCII letter
+asciiLetter :: Parsec Void Text Char
+asciiLetter = satisfy isAsciiLetter <?> "ascii letter"
+ where
+  isAsciiLetter c = do
+    let code = ord c
+    isCodeAsciiUpper code || isCodeAsciiLower code
+{-# INLINE asciiLetter #-}
+
+-- | Parse a single ASCII digit
+asciiDigit :: Parsec Void Text Char
+asciiDigit = satisfy (isCodeAsciiDigit . ord) <?> "ascii digit"
+{-# INLINE asciiDigit #-}
+
+isCodeAsciiUpper :: Int -> Bool
+isCodeAsciiUpper code = ord 'A' <= code && code <= ord 'Z'
+{-# INLINE isCodeAsciiUpper #-}
+
+isCodeAsciiLower :: Int -> Bool
+isCodeAsciiLower code = ord 'a' <= code && code <= ord 'z'
+{-# INLINE isCodeAsciiLower #-}
+
+isCodeAsciiDigit :: Int -> Bool
+isCodeAsciiDigit code = ord '0' <= code && code <= ord '9'
+{-# INLINE isCodeAsciiDigit #-}

--- a/bcp47/library/Data/BCP47/Internal/PrivateUse.hs
+++ b/bcp47/library/Data/BCP47/Internal/PrivateUse.hs
@@ -15,6 +15,7 @@ import Data.BCP47.Internal.Arbitrary
   (Arbitrary, alphaNumString, arbitrary, choose)
 import Data.BCP47.Internal.Parser (complete, asciiLetterDigit)
 import Data.Bifunctor (first)
+import Data.CaseInsensitive (CI, mk)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text, pack)
@@ -28,14 +29,14 @@ import Text.Megaparsec.Error (errorBundlePretty)
 -- Private use subtags are used to indicate distinctions in language
 -- that are important in a given context by private agreement.
 --
-newtype PrivateUse = PrivateUse { privateUseToText :: Text }
+newtype PrivateUse = PrivateUse { privateUseToText :: CI Text }
   deriving stock (Show, Eq, Ord)
 
 instance Arbitrary PrivateUse where
   arbitrary = do
     len <- choose (1, 8)
     chars <- alphaNumString len
-    pure . PrivateUse $ pack chars
+    pure . PrivateUse . mk $ pack chars
 
 -- | Parse a 'PrivateUse' subtag from 'Text'
 privateUseFromText :: Text -> Either Text (Set PrivateUse)
@@ -52,4 +53,4 @@ privateUseP :: Parsec Void Text (Set PrivateUse)
 privateUseP = complete $ do
   void $ char 'x' <|> char 'X'
   rest <- some (char '-' *> count' 1 8 asciiLetterDigit)
-  pure $ Set.fromList $ PrivateUse . pack <$> rest
+  pure $ Set.fromList $ PrivateUse . mk . pack <$> rest

--- a/bcp47/library/Data/BCP47/Internal/PrivateUse.hs
+++ b/bcp47/library/Data/BCP47/Internal/PrivateUse.hs
@@ -9,17 +9,18 @@ module Data.BCP47.Internal.PrivateUse
   )
 where
 
+import Control.Applicative ((<|>))
 import Control.Monad (void)
 import Data.BCP47.Internal.Arbitrary
   (Arbitrary, alphaNumString, arbitrary, choose)
-import Data.BCP47.Internal.Parser (complete)
+import Data.BCP47.Internal.Parser (complete, asciiLetterDigit)
 import Data.Bifunctor (first)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text, pack)
 import Data.Void (Void)
 import Text.Megaparsec (Parsec, count', parse, some)
-import Text.Megaparsec.Char (alphaNumChar, char)
+import Text.Megaparsec.Char (char)
 import Text.Megaparsec.Error (errorBundlePretty)
 
 -- | Private Use subtags
@@ -49,6 +50,6 @@ privateUseFromText =
 --
 privateUseP :: Parsec Void Text (Set PrivateUse)
 privateUseP = complete $ do
-  void $ char 'x'
-  rest <- some (char '-' *> count' 1 8 alphaNumChar)
+  void $ char 'x' <|> char 'X'
+  rest <- some (char '-' *> count' 1 8 asciiLetterDigit)
   pure $ Set.fromList $ PrivateUse . pack <$> rest

--- a/bcp47/library/Data/BCP47/Internal/Region.hs
+++ b/bcp47/library/Data/BCP47/Internal/Region.hs
@@ -8,12 +8,11 @@ where
 
 import Control.Applicative ((<|>))
 import Country (Country, alphaTwoUpper, decodeAlphaTwo, decodeNumeric)
-import Data.BCP47.Internal.Parser (complete)
+import Data.BCP47.Internal.Parser (complete, asciiLetter, asciiDigit)
 import Data.Bifunctor (first)
-import Data.Text (Text, pack)
+import Data.Text (Text, pack, toUpper)
 import Data.Void (Void)
 import Text.Megaparsec (Parsec, count, parse, try, (<?>))
-import Text.Megaparsec.Char (digitChar, upperChar)
 import Text.Megaparsec.Error (errorBundlePretty)
 import Text.Read (readEither)
 
@@ -22,14 +21,23 @@ regionToText = alphaTwoUpper
 
 -- | Parse a region subtag from 'Text'
 --
+-- >>> regionFromText $ pack "zw"
+-- Right zimbabwe
+--
 -- >>> regionFromText $ pack "ZW"
+-- Right zimbabwe
+--
+-- >>> regionFromText $ pack "Zw"
+-- Right zimbabwe
+--
+-- >>> regionFromText $ pack "zW"
 -- Right zimbabwe
 --
 -- >>> regionFromText $ pack "012"
 -- Right algeria
 --
 -- >>> regionFromText $ pack "asdf"
--- Left "regionFromText:1:1:\n  |\n1 | asdf\n  | ^\nunexpected 'a'\nexpecting 2 or 3 character country code\n"
+-- Left "regionFromText:1:3:\n  |\n1 | asdf\n  |   ^\nunexpected 'd'\nexpecting 2 or 3 character country code\n"
 --
 regionFromText :: Text -> Either Text Country
 regionFromText =
@@ -43,16 +51,20 @@ regionFromText =
 -- @@
 --
 regionP :: Parsec Void Text Country
-regionP = complete (try alpha2 <|> num3 <?> "2 or 3 character country code")
+regionP =
+  try (complete alpha2)
+  <|> try (complete num3)
+  <?> "2 or 3 character country code"
  where
-  alpha2 =
-    maybe (fail "Invalid 2 character country code") pure
-      . decodeAlphaTwo
-      . pack
-      =<< count 2 upperChar
-  num3 =
-    maybe (fail "Invalid 3 character country code") pure
-      . decodeNumeric
-      =<< either fail pure
-      . readEither
-      =<< count 3 digitChar
+  alpha2 = do
+    code <- pack <$> count 2 asciiLetter
+    let region = decodeAlphaTwo $ toUpper code
+    unwrap "Invalid 2 character country code" region
+
+  num3 = do
+    code <- count 3 asciiDigit
+    region <- decodeNumeric <$> either fail pure (readEither code)
+    unwrap "Invalid 3 character country code" region
+
+unwrap :: MonadFail m => String -> Maybe a -> m a
+unwrap message = maybe (fail message) pure

--- a/bcp47/library/Data/BCP47/Internal/Script.hs
+++ b/bcp47/library/Data/BCP47/Internal/Script.hs
@@ -12,6 +12,7 @@ where
 import Data.BCP47.Internal.Arbitrary (Arbitrary, alphaString, arbitrary)
 import Data.BCP47.Internal.Parser (complete, asciiLetter)
 import Data.Bifunctor (first)
+import Data.CaseInsensitive (CI, mk)
 import Data.Text (Text, pack)
 import Data.Void (Void)
 import Text.Megaparsec (Parsec, count, parse)
@@ -23,11 +24,11 @@ import Text.Megaparsec.Error (errorBundlePretty)
 -- variations that distinguish the written forms of a language or its
 -- dialects.
 --
-newtype Script = Script { scriptToText :: Text }
+newtype Script = Script { scriptToText :: CI Text }
   deriving stock (Show, Eq, Ord)
 
 instance Arbitrary Script where
-  arbitrary = Script . pack <$> alphaString 4
+  arbitrary = Script . mk . pack <$> alphaString 4
 
 -- | Parse a 'Script' subtag from 'Text'
 scriptFromText :: Text -> Either Text Script
@@ -41,4 +42,4 @@ scriptFromText =
 -- @@
 --
 scriptP :: Parsec Void Text Script
-scriptP = complete $ Script . pack <$> count 4 asciiLetter
+scriptP = complete $ Script . mk . pack <$> count 4 asciiLetter

--- a/bcp47/library/Data/BCP47/Internal/Script.hs
+++ b/bcp47/library/Data/BCP47/Internal/Script.hs
@@ -10,9 +10,10 @@ module Data.BCP47.Internal.Script
 where
 
 import Data.BCP47.Internal.Arbitrary (Arbitrary, alphaString, arbitrary)
+import Data.BCP47.Internal.CIText (CIText)
+import qualified Data.BCP47.Internal.CIText as CI
 import Data.BCP47.Internal.Parser (complete, asciiLetter)
 import Data.Bifunctor (first)
-import Data.CaseInsensitive (CI, mk)
 import Data.Text (Text, pack)
 import Data.Void (Void)
 import Text.Megaparsec (Parsec, count, parse)
@@ -24,11 +25,14 @@ import Text.Megaparsec.Error (errorBundlePretty)
 -- variations that distinguish the written forms of a language or its
 -- dialects.
 --
-newtype Script = Script { scriptToText :: CI Text }
+newtype Script = Script { unScript :: CIText }
   deriving stock (Show, Eq, Ord)
 
+scriptToText :: Script -> Text
+scriptToText = CI.original . unScript
+
 instance Arbitrary Script where
-  arbitrary = Script . mk . pack <$> alphaString 4
+  arbitrary = Script . CI.pack <$> alphaString 4
 
 -- | Parse a 'Script' subtag from 'Text'
 scriptFromText :: Text -> Either Text Script
@@ -42,4 +46,4 @@ scriptFromText =
 -- @@
 --
 scriptP :: Parsec Void Text Script
-scriptP = complete $ Script . mk . pack <$> count 4 asciiLetter
+scriptP = complete $ Script . CI.pack <$> count 4 asciiLetter

--- a/bcp47/library/Data/BCP47/Internal/Script.hs
+++ b/bcp47/library/Data/BCP47/Internal/Script.hs
@@ -10,12 +10,11 @@ module Data.BCP47.Internal.Script
 where
 
 import Data.BCP47.Internal.Arbitrary (Arbitrary, alphaString, arbitrary)
-import Data.BCP47.Internal.Parser (complete)
+import Data.BCP47.Internal.Parser (complete, asciiLetter)
 import Data.Bifunctor (first)
 import Data.Text (Text, pack)
 import Data.Void (Void)
 import Text.Megaparsec (Parsec, count, parse)
-import Text.Megaparsec.Char (letterChar)
 import Text.Megaparsec.Error (errorBundlePretty)
 
 -- | Script subtags
@@ -42,4 +41,4 @@ scriptFromText =
 -- @@
 --
 scriptP :: Parsec Void Text Script
-scriptP = complete $ Script . pack <$> count 4 letterChar
+scriptP = complete $ Script . pack <$> count 4 asciiLetter

--- a/bcp47/library/Data/BCP47/Internal/Variant.hs
+++ b/bcp47/library/Data/BCP47/Internal/Variant.hs
@@ -12,12 +12,11 @@ module Data.BCP47.Internal.Variant
 import Control.Applicative ((<|>))
 import Data.BCP47.Internal.Arbitrary
   (Arbitrary, alphaNumString, arbitrary, choose, numChar, oneof)
-import Data.BCP47.Internal.Parser (complete)
+import Data.BCP47.Internal.Parser (complete, asciiLetterDigit, asciiDigit)
 import Data.Bifunctor (first)
 import Data.Text (Text, pack)
 import Data.Void (Void)
 import Text.Megaparsec (Parsec, count, count', parse, try)
-import Text.Megaparsec.Char (alphaNumChar, digitChar)
 import Text.Megaparsec.Error (errorBundlePretty)
 
 -- | BCP-47 variant parser
@@ -32,11 +31,11 @@ variantP =
   complete
     $ Variant
     . pack
-    <$> (try (count' 5 8 alphaNumChar) <|> digitPrefixed)
+    <$> (try (count' 5 8 asciiLetterDigit) <|> digitPrefixed)
  where
   digitPrefixed = do
-    x <- digitChar
-    xs <- count 3 alphaNumChar
+    x <- asciiDigit
+    xs <- count 3 asciiLetterDigit
     pure $ x : xs
 
 -- | Variant subtags

--- a/bcp47/library/Data/BCP47/Internal/Variant.hs
+++ b/bcp47/library/Data/BCP47/Internal/Variant.hs
@@ -14,6 +14,7 @@ import Data.BCP47.Internal.Arbitrary
   (Arbitrary, alphaNumString, arbitrary, choose, numChar, oneof)
 import Data.BCP47.Internal.Parser (complete, asciiLetterDigit, asciiDigit)
 import Data.Bifunctor (first)
+import Data.CaseInsensitive (CI, mk)
 import Data.Text (Text, pack)
 import Data.Void (Void)
 import Text.Megaparsec (Parsec, count, count', parse, try)
@@ -30,6 +31,7 @@ variantP :: Parsec Void Text Variant
 variantP =
   complete
     $ Variant
+    . mk
     . pack
     <$> (try (count' 5 8 asciiLetterDigit) <|> digitPrefixed)
  where
@@ -44,7 +46,7 @@ variantP =
 -- variations that define a language or its dialects that are not
 -- covered by other available subtags.
 --
-newtype Variant = Variant { variantToText :: Text }
+newtype Variant = Variant { variantToText :: CI Text }
   deriving stock (Show, Eq, Ord)
 
 instance Arbitrary Variant where
@@ -53,11 +55,11 @@ instance Arbitrary Variant where
     alphaNum = do
       len <- choose (5, 8)
       chars <- alphaNumString len
-      pure . Variant $ pack chars
+      pure . Variant $ mk $ pack chars
     digitPrefixed = do
       prefix <- numChar
       chars <- alphaNumString 3
-      pure . Variant $ pack $ prefix : chars
+      pure . Variant $ mk $ pack $ prefix : chars
 
 -- | Parse a 'Variant' subtag from 'Text'
 variantFromText :: Text -> Either Text Variant

--- a/bcp47/library/Data/BCP47/Internal/Variant.hs
+++ b/bcp47/library/Data/BCP47/Internal/Variant.hs
@@ -12,9 +12,10 @@ module Data.BCP47.Internal.Variant
 import Control.Applicative ((<|>))
 import Data.BCP47.Internal.Arbitrary
   (Arbitrary, alphaNumString, arbitrary, choose, numChar, oneof)
+import Data.BCP47.Internal.CIText (CIText)
+import qualified Data.BCP47.Internal.CIText as CI
 import Data.BCP47.Internal.Parser (complete, asciiLetterDigit, asciiDigit)
 import Data.Bifunctor (first)
-import Data.CaseInsensitive (CI, mk)
 import Data.Text (Text, pack)
 import Data.Void (Void)
 import Text.Megaparsec (Parsec, count, count', parse, try)
@@ -31,8 +32,7 @@ variantP :: Parsec Void Text Variant
 variantP =
   complete
     $ Variant
-    . mk
-    . pack
+    . CI.pack
     <$> (try (count' 5 8 asciiLetterDigit) <|> digitPrefixed)
  where
   digitPrefixed = do
@@ -46,8 +46,11 @@ variantP =
 -- variations that define a language or its dialects that are not
 -- covered by other available subtags.
 --
-newtype Variant = Variant { variantToText :: CI Text }
+newtype Variant = Variant { unVariant :: CIText }
   deriving stock (Show, Eq, Ord)
+
+variantToText :: Variant -> Text
+variantToText = CI.original . unVariant
 
 instance Arbitrary Variant where
   arbitrary = oneof [alphaNum, digitPrefixed]
@@ -55,11 +58,11 @@ instance Arbitrary Variant where
     alphaNum = do
       len <- choose (5, 8)
       chars <- alphaNumString len
-      pure . Variant $ mk $ pack chars
+      pure . Variant $ CI.pack chars
     digitPrefixed = do
       prefix <- numChar
       chars <- alphaNumString 3
-      pure . Variant $ mk $ pack $ prefix : chars
+      pure . Variant $ CI.pack $ prefix : chars
 
 -- | Parse a 'Variant' subtag from 'Text'
 variantFromText :: Text -> Either Text Variant

--- a/bcp47/package.yaml
+++ b/bcp47/package.yaml
@@ -38,13 +38,14 @@ dependencies:
 library:
   source-dirs: library
   dependencies:
-  - QuickCheck
   - aeson
+  - case-insensitive
   - containers
-  - generic-arbitrary
   - country
+  - generic-arbitrary
   - iso639
   - megaparsec
+  - QuickCheck
   - text
 
 tests:

--- a/bcp47/tests/Data/BCP47/TrieSpec.hs
+++ b/bcp47/tests/Data/BCP47/TrieSpec.hs
@@ -94,6 +94,10 @@ spec = do
       let Just trie = fromList [(en, "color"), (enGB, "colour")]
       lookup enGBTJP trie `shouldBe` Just "colour"
 
+    it "lookups case-insensitively" $ do
+      let Just trie = fromList [(enTJPUpper, "color"), (enGBTJPUpper, "color")]
+      lookup enTJP trie `shouldBe` Just "color"
+
   describe "match" $ do
     it "should always match a path it inserts" $ property $ \tag ->
       match tag (singleton tag "string") `shouldBe` Just "string"
@@ -125,3 +129,7 @@ spec = do
     it "matches a deep relevant match" $ do
       let Just trie = fromList [(en, "color"), (enGB, "colour")]
       match enGBTJP trie `shouldBe` Nothing
+
+    it "matches case-insensitively" $ do
+      let Just trie = fromList [(enTJPUpper, "color"), (enGBTJPUpper, "color")]
+      match enTJP trie `shouldBe` Just "color"


### PR DESCRIPTION
According to [the RFC](rfc-editor.org/rfc/bcp/bcp47.txt), language tags and subtags are meant to be handled case-insensitively:

> At all times, language tags and their subtags, including private use
> and extensions, are to be treated as case insensitive: there exist
> conventions for the capitalization of some of the subtags, but these
> MUST NOT be taken to carry meaning.

They are also ASCII-only, though they can be encoded in schemes that include ASCII:

> Although [RFC5234] refers to octets, the language tags described in
> this document are sequences of characters from the US-ASCII [ISO646]
> repertoire.  Language tags MAY be used in documents and applications
> that use other encodings, so long as these encompass the relevant
> part of the US-ASCII repertoire.  An example of this would be an XML
> document that uses the UTF-16LE [RFC2781] encoding of [Unicode].

This has bitten us recently with [our backend failing to accept `en-gb`](https://github.com/freckle/bcp47/issues/21#issuecomment-870953201). Instead, we should parse tags and subtags without respect to case, and we should also allow lookups to be case-insensitive. `Language` and `Country` are already stored in a canonical format, so they don't need special treatment, but all of our subtags were just `newtype`s around `Text`. I've added another newtype `CIText = CIText { unCIText :: CI Text }` and used that instead. This was less noisey than inlining `CI Text` everywhere.

@eborden I don't fully understand the `Trie` stuff, but I did add some tests, so let me know if I broke anything.