### PR TITLE
Fix `Trie2` `Semigroup` instance

### DIFF
--- a/bcp47/ChangeLog.md
+++ b/bcp47/ChangeLog.md
@@ -1,6 +1,10 @@
-## [*Unreleased*](https://github.com/freckle/bcp47/compare/bcp47-v0.2.0.4...main)
+## [*Unreleased*](https://github.com/freckle/bcp47/compare/bcp47-v0.2.0.5...main)
 
 None
+
+## [v0.2.0.5](https://github.com/freckle/bcp47/compare/bcp47-v0.2.0.4...bcp47-v0.2.0.5)
+
+- Fix `Semigroup` instance of `Trie` ([PR #29](https://github.com/freckle/bcp47/pull/29))
 
 ## [v0.2.0.4](https://github.com/freckle/bcp47/compare/bcp47-v0.2.0.3...bcp47-v0.2.0.4)
 

--- a/bcp47/library/Data/BCP47/Trie/Internal.hs
+++ b/bcp47/library/Data/BCP47/Trie/Internal.hs
@@ -122,4 +122,4 @@ union2 = union2Using (<|>)
 
 union2Using :: (Maybe a -> Maybe a -> Maybe a) -> Trie2 a -> Trie2 a -> Trie2 a
 union2Using f (Trie2 x xs) (Trie2 y ys) =
-  Trie2 (f x y) (Map.unionWith union2 xs ys)
+  Trie2 (f x y) (Map.unionWith (union2Using f) xs ys)

--- a/bcp47/package.yaml
+++ b/bcp47/package.yaml
@@ -1,5 +1,5 @@
 name: bcp47
-version: 0.2.0.4
+version: 0.2.0.5
 github:  "freckle/bcp47"
 license: MIT
 author: "Evan Rutledge Borden"

--- a/bcp47/tests/Data/BCP47/TrieSpec.hs
+++ b/bcp47/tests/Data/BCP47/TrieSpec.hs
@@ -30,10 +30,12 @@ spec = do
 
     describe "Semigroup instance" $ do
       it "unions top-level conflicts" $ property $ \l r ->
-        lookup en (singleton en [l] <> singleton en [r]) `shouldBe` Just ([l, r] :: [Int])
+        lookup en (singleton en [l] <> singleton en [r])
+          `shouldBe` Just ([l, r] :: [Int])
 
       it "unions leaf-level conflicts" $ property $ \v1 v2 -> do
-        lookup enGB (singleton enGB [v1] <> singleton enGB [v2]) `shouldBe` Just ([v1, v2] :: [Int])
+        lookup enGB (singleton enGB [v1] <> singleton enGB [v2])
+          `shouldBe` Just ([v1, v2] :: [Int])
 
     describe "mapMaybe" $ do
       it "Justs are constant" $ property $ \xs ->

--- a/bcp47/tests/Data/BCP47/TrieSpec.hs
+++ b/bcp47/tests/Data/BCP47/TrieSpec.hs
@@ -28,6 +28,13 @@ spec = do
       < singleton es "color"
       `shouldBe` True
 
+    describe "Semigroup instance" $ do
+      it "unions top-level conflicts" $ property $ \l r ->
+        lookup en (singleton en [l] <> singleton en [r]) `shouldBe` Just ([l, r] :: [Int])
+
+      it "unions leaf-level conflicts" $ property $ \v1 v2 -> do
+        lookup enGB (singleton enGB [v1] <> singleton enGB [v2]) `shouldBe` Just ([v1, v2] :: [Int])
+
     describe "mapMaybe" $ do
       it "Justs are constant" $ property $ \xs ->
         let


### PR DESCRIPTION
**How?**

The instance was using `<>` to combine values at the top level but `<|>` at lower
levels. This uses `<>` at all levels.

**Please Advise**

On how to version this. Could break code that's out there, won't break compilation.