### PR TITLE
Add a Serialise instance to BCP47

### DIFF
--- a/bcp47/ChangeLog.md
+++ b/bcp47/ChangeLog.md
@@ -1,6 +1,10 @@
-## [*Unreleased*](https://github.com/freckle/bcp47/compare/bcp47-v0.2.0.6...main)
+## [*Unreleased*](https://github.com/freckle/bcp47/compare/bcp47-v0.2.0.7...main)
 
 None
+
+## [v0.2.0.7](https://github.com/freckle/bcp47/compare/bcp47-v0.2.0.6...bcp47-v0.2.0.7)
+
+- Support Serialise
 
 ## [v0.2.0.6](https://github.com/freckle/bcp47/compare/bcp47-v0.2.0.5...bcp47-v0.2.0.6)
 

--- a/bcp47/bcp47.cabal
+++ b/bcp47/bcp47.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: 91c95ed208d7d9d117e3a4b00d7ffc44b087252a2c1f260910286b3644a5b36e
 
 name:           bcp47
-version:        0.2.0.6
+version:        0.2.0.7
 synopsis:       Language tags as specified by BCP 47
 description:    /Language tags for use in cases where it is desirable to indicate the/
                 /language used in an information object./
@@ -75,6 +75,7 @@ library
     , generic-arbitrary
     , iso639
     , megaparsec
+    , serialise
     , text
   default-language: Haskell2010
 
@@ -109,5 +110,6 @@ test-suite spec
     , country
     , hspec
     , iso639
+    , serialise
     , text
   default-language: Haskell2010

--- a/bcp47/library/Data/BCP47.hs
+++ b/bcp47/library/Data/BCP47.hs
@@ -1,7 +1,7 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DeriveGeneric #-}
 
 -- | /Human beings on our planet have, past and present, used a number of/
 -- /languages. There are many reasons why one would want to identify the/
@@ -159,9 +159,11 @@ instance FromJSON BCP47 where
 
 instance Serialise.Serialise BCP47 where
   -- bypass children not having their own Serialise instances by using toText/fromText
-  encode bcp = Serialise.encodeListLen 2 <> Serialise.encodeTag 0 <> Serialise.encodeString (toText bcp)
+  encode bcp =
+    Serialise.encodeListLen 2 <> Serialise.encodeTag 0 <> Serialise.encodeString
+      (toText bcp)
   decode = do
-    -- these two must be read to consume them 
+    -- these two must be read to consume them
     -- ignore them as they're here as part of the standard format but we don't need them
     void Serialise.decodeListLen
     void Serialise.decodeTag

--- a/bcp47/package.yaml
+++ b/bcp47/package.yaml
@@ -1,5 +1,5 @@
 name: bcp47
-version: 0.2.0.6
+version: 0.2.0.7
 github:  "freckle/bcp47"
 license: MIT
 author: "Evan Rutledge Borden"
@@ -46,6 +46,7 @@ library:
   - iso639
   - megaparsec
   - QuickCheck
+  - serialise
   - text
 
 tests:
@@ -65,4 +66,5 @@ tests:
     - hspec
     - country
     - iso639
+    - serialise
     - text

--- a/bcp47/tests/Data/BCP47Spec.hs
+++ b/bcp47/tests/Data/BCP47Spec.hs
@@ -8,6 +8,7 @@ module Data.BCP47Spec
 
 import TestImport
 
+import qualified Codec.Serialise as S
 import Country.Identifier (china)
 import Data.Aeson (decode, encode)
 import Data.BCP47
@@ -56,6 +57,9 @@ spec = do
 
   describe "ToJSON/FromJSON" . it "roundtrips" . property $ \x ->
     decode (encode @BCP47 x) `shouldBe` Just x
+
+  describe "Serialise" . it "roundtrips" . property $ \x ->
+    S.deserialise @BCP47 (S.serialise @BCP47 x) `shouldBe` x
 
   describe "Eq" $ do
     it "compares equal with different casing" $ do


### PR DESCRIPTION
# Description

The CBOR format is a valuable addition for consumers who may want to use Serialise. To allow them to more easily derive their own instances, we provide one for `BCP47`.