### PR TITLE
Move aeson instances to bcp47-orphans

### DIFF
--- a/bcp47-orphans/ChangeLog.md
+++ b/bcp47-orphans/ChangeLog.md
@@ -2,7 +2,11 @@
 
 None
 
-## [v0.1.0.5](https://github.com/freckle/bcp47/compare/bcp47-orphans-v0.1.0.5...bcp47-orphans-v0.1.0.6)
+## [v0.1.1.0](https://github.com/freckle/bcp47/compare/bcp47-orphans-v0.1.0.6...bcp47-orphans-v0.1.1.0)
+
+- Add `FromJSON` and `ToJSON` instances (removed from `bcp47-0.3.0.0`)
+
+## [v0.1.0.6](https://github.com/freckle/bcp47/compare/bcp47-orphans-v0.1.0.5...bcp47-orphans-v0.1.0.6)
 
 - Add support for Serialise and the CBOR format
 

--- a/bcp47-orphans/ChangeLog.md
+++ b/bcp47-orphans/ChangeLog.md
@@ -1,4 +1,4 @@
-## [*Unreleased*](https://github.com/freckle/bcp47/compare/bcp47-orphans-v0.1.0.6...main)
+## [*Unreleased*](https://github.com/freckle/bcp47/compare/bcp47-orphans-v0.1.1.0...main)
 
 None
 

--- a/bcp47-orphans/bcp47-orphans.cabal
+++ b/bcp47-orphans/bcp47-orphans.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5c79d9e87de963f1d0a979ce5f7ccea1e62d1ea4857eba1515a06d4cf95d776c
+-- hash: d42854720beede548338498a5cc2b5897fd9882a83a12c3796199b4add4b3cf3
 
 name:           bcp47-orphans
-version:        0.1.0.6
+version:        0.1.1.0
 synopsis:       BCP47 orphan instances
 description:    Orphan instances for the BCP47 type
 category:       Orphan Instances
@@ -44,7 +44,7 @@ library
   build-depends:
       aeson
     , base >=4.7 && <5
-    , bcp47
+    , bcp47 >=0.3.0.0
     , cassava
     , errors
     , esqueleto

--- a/bcp47-orphans/bcp47-orphans.cabal
+++ b/bcp47-orphans/bcp47-orphans.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.38.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e88408b4a95a2e691e0160fdbb5b1de8943a9953070afa597e9970e6c40a9af8
+-- hash: 5c79d9e87de963f1d0a979ce5f7ccea1e62d1ea4857eba1515a06d4cf95d776c
 
 name:           bcp47-orphans
 version:        0.1.0.6
@@ -29,6 +29,7 @@ source-repository head
 
 library
   exposed-modules:
+      Data.BCP47.Aeson
       Data.BCP47.Csv
       Data.BCP47.Esqueleto
       Data.BCP47.Hashable
@@ -41,7 +42,8 @@ library
   hs-source-dirs:
       library
   build-depends:
-      base >=4.7 && <5
+      aeson
+    , base >=4.7 && <5
     , bcp47
     , cassava
     , errors
@@ -58,6 +60,7 @@ test-suite spec
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      Data.BCP47.AesonSpec
       Data.BCP47.CsvSpec
       Data.BCP47.PathPiecesSpec
       Data.BCP47.PersistSpec
@@ -68,6 +71,7 @@ test-suite spec
       tests
   build-depends:
       QuickCheck
+    , aeson
     , base >=4.7 && <5
     , bcp47
     , bcp47-orphans

--- a/bcp47-orphans/library/Data/BCP47/Aeson.hs
+++ b/bcp47-orphans/library/Data/BCP47/Aeson.hs
@@ -1,0 +1,14 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Data.BCP47.Aeson () where
+
+import Data.Aeson
+import Data.BCP47
+import Data.Text (unpack)
+
+instance ToJSON BCP47 where
+  toEncoding = toEncoding . toText
+  toJSON = toJSON . toText
+
+instance FromJSON BCP47 where
+  parseJSON = withText "BCP47" $ either (fail . unpack) pure . fromText

--- a/bcp47-orphans/package.yaml
+++ b/bcp47-orphans/package.yaml
@@ -19,6 +19,7 @@ dependencies:
 library:
   source-dirs: library
   dependencies:
+  - aeson
   - bcp47
   - cassava
   - errors
@@ -36,6 +37,7 @@ tests:
     source-dirs: tests
     dependencies:
     - QuickCheck
+    - aeson
     - bcp47
     - bcp47-orphans
     - cassava

--- a/bcp47-orphans/package.yaml
+++ b/bcp47-orphans/package.yaml
@@ -1,5 +1,5 @@
 name: bcp47-orphans
-version: 0.1.0.6
+version: 0.1.1.0
 github: "freckle/bcp47"
 license: MIT
 author: "Evan Rutledge Borden"
@@ -20,7 +20,7 @@ library:
   source-dirs: library
   dependencies:
   - aeson
-  - bcp47
+  - bcp47 >= 0.3.0.0
   - cassava
   - errors
   - esqueleto

--- a/bcp47-orphans/tests/Data/BCP47/AesonSpec.hs
+++ b/bcp47-orphans/tests/Data/BCP47/AesonSpec.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Data.BCP47.AesonSpec
+  ( spec
+  ) where
+
+import Data.Aeson
+import Data.BCP47
+import Data.BCP47.Aeson ()
+import Test.Hspec
+import Test.Hspec.QuickCheck
+
+spec :: Spec
+spec = do
+  describe "ToJSON/FromJSON" $ do
+    prop "roundtrips" $ \x ->
+      decode (encode @BCP47 x) `shouldBe` Just x

--- a/bcp47/ChangeLog.md
+++ b/bcp47/ChangeLog.md
@@ -1,4 +1,4 @@
-## [*Unreleased*](https://github.com/freckle/bcp47/compare/bcp47-v0.2.0.6...main)
+## [*Unreleased*](https://github.com/freckle/bcp47/compare/bcp47-v0.3.0.0...main)
 
 None
 

--- a/bcp47/ChangeLog.md
+++ b/bcp47/ChangeLog.md
@@ -2,6 +2,10 @@
 
 None
 
+## [v0.3.0.0](https://github.com/freckle/bcp47/compare/bcp47-v0.2.0.6...bcp47-v0.3.0.0)
+
+- Remove `FromJSON` and `ToJSON` instances (added to `bcp47-orphans-0.1.1.0`)
+
 ## [v0.2.0.6](https://github.com/freckle/bcp47/compare/bcp47-v0.2.0.5...bcp47-v0.2.0.6)
 
 - Support GHCs 9.0 and 9.2

--- a/bcp47/bcp47.cabal
+++ b/bcp47/bcp47.cabal
@@ -1,13 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.38.0.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 91c95ed208d7d9d117e3a4b00d7ffc44b087252a2c1f260910286b3644a5b36e
 
 name:           bcp47
-version:        0.2.0.6
+version:        0.3.0.0
 synopsis:       Language tags as specified by BCP 47
 description:    /Language tags for use in cases where it is desirable to indicate the/
                 /language used in an information object./
@@ -67,7 +65,6 @@ library
       library
   build-depends:
       QuickCheck
-    , aeson
     , base >=4.7 && <5
     , case-insensitive
     , containers
@@ -102,7 +99,6 @@ test-suite spec
       tests
   build-depends:
       QuickCheck
-    , aeson
     , base >=4.7 && <5
     , bcp47
     , containers

--- a/bcp47/library/Data/BCP47.hs
+++ b/bcp47/library/Data/BCP47.hs
@@ -97,7 +97,6 @@ import Country.Identifier
   ( unitedKingdomOfGreatBritainAndNorthernIreland
   , unitedStatesOfAmerica
   )
-import Data.Aeson
 import Data.BCP47.Internal.Arbitrary
   ( Arbitrary
   , arbitrary
@@ -121,7 +120,7 @@ import qualified Data.List as List
 import Data.Maybe (mapMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.Text (Text, pack, unpack)
+import Data.Text (Text, pack)
 import qualified Data.Text as T
 import Data.Void (Void)
 import Text.Megaparsec (Parsec, eof, hidden, many, optional, parse, try)
@@ -165,13 +164,6 @@ instance Read BCP47 where
   readsPrec _ s = case fromText $ T.pack s of
     Left _ -> []
     Right b -> [(b, "")]
-
-instance ToJSON BCP47 where
-  toEncoding = toEncoding . toText
-  toJSON = toJSON . toText
-
-instance FromJSON BCP47 where
-  parseJSON = withText "BCP47" $ either (fail . unpack) pure . fromText
 
 -- | Serialize @'BCP47'@ to @'Text'@
 --

--- a/bcp47/package.yaml
+++ b/bcp47/package.yaml
@@ -1,5 +1,5 @@
 name: bcp47
-version: 0.2.0.6
+version: 0.3.0.0
 github:  "freckle/bcp47"
 license: MIT
 author: "Evan Rutledge Borden"

--- a/bcp47/package.yaml
+++ b/bcp47/package.yaml
@@ -38,7 +38,6 @@ dependencies:
 library:
   source-dirs: library
   dependencies:
-  - aeson
   - case-insensitive
   - containers
   - country
@@ -59,7 +58,6 @@ tests:
     source-dirs: tests
     dependencies:
     - QuickCheck
-    - aeson
     - bcp47
     - containers
     - hspec

--- a/bcp47/tests/Data/BCP47Spec.hs
+++ b/bcp47/tests/Data/BCP47Spec.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 module Data.BCP47Spec
   ( spec
@@ -9,7 +9,6 @@ module Data.BCP47Spec
 import TestImport
 
 import Country.Identifier (china)
-import Data.Aeson (decode, encode)
 import Data.BCP47
 import Data.BCP47.Internal.Extension
 import Data.BCP47.Internal.LanguageExtension
@@ -17,15 +16,16 @@ import Data.BCP47.Internal.PrivateUse
 import Data.BCP47.Internal.Script
 import Data.BCP47.Internal.Variant
 import Data.Either (isRight)
-import Data.LanguageCodes (ISO639_1(ZH))
+import Data.LanguageCodes (ISO639_1 (ZH))
 import qualified Data.Set as Set
 
 spec :: Spec
 spec = do
   describe "fromText" $ do
     it "parses all components" $ do
-      lng <- fromTextThrows
-        "zh-abc-def-zxy-Hant-CN-1967-y-extensi-x-private1-private2"
+      lng <-
+        fromTextThrows
+          "zh-abc-def-zxy-Hant-CN-1967-y-extensi-x-private1-private2"
       language lng `shouldBe` ZH
       extendedLanguageSubtags lng
         `shouldBe` Set.singleton (LanguageExtension "abc-def-zxy")
@@ -54,15 +54,14 @@ spec = do
   describe "Read/Show" . it "can roundtrip" . property $ \tag ->
     readMaybe (show @BCP47 tag) `shouldBe` Just tag
 
-  describe "ToJSON/FromJSON" . it "roundtrips" . property $ \x ->
-    decode (encode @BCP47 x) `shouldBe` Just x
-
   describe "Eq" $ do
     it "compares equal with different casing" $ do
-      lower <- fromTextThrows
-        "zh-abc-def-zxy-hant-cn-1967-y-extensi-x-private1-private2"
-      upper <- fromTextThrows
-        "ZH-ABC-DEF-ZXY-HANT-CN-1967-Y-EXTENSI-X-PRIVATE1-PRIVATE2"
+      lower <-
+        fromTextThrows
+          "zh-abc-def-zxy-hant-cn-1967-y-extensi-x-private1-private2"
+      upper <-
+        fromTextThrows
+          "ZH-ABC-DEF-ZXY-HANT-CN-1967-Y-EXTENSI-X-PRIVATE1-PRIVATE2"
       upper `shouldBe` lower
 
   describe "Regression tests" $ do


### PR DESCRIPTION
### [Move aeson instances to bcp47-orphans](https://github.com/freckle/bcp47/pull/51/commits/325a0bc95e0c63e35031729941c8975dbd97a740) 
325a0bc
This is really where they should've always been (to avoid the aeson
dependency in the core package), but the move is happening now because
we want to add `HasCodec` instances and define as many en/decoding
instances as possible in terms of it. Since `HasCodec` will definitely
go into `-orphans`, the aeson instances must live there too.

See #41.

### [Version bump](https://github.com/freckle/bcp47/pull/51/commits/6a9ead228b32ae8d627fd2baa711b55b970d3804) 
6a9ead2
This is a major version bump for `bcp47` (removal) and a minor bump for
`bcp47-orphans` (addition). In the latter, we also set a bound on the
former so we can't build a case where they're defined in both.