### PR TITLE
Fix release for removed LTS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,4 +29,4 @@ jobs:
           working-directory: ${{ matrix.package }}
         env:
           HACKAGE_API_KEY: ${{ secrets.HACKAGE_UPLOAD_API_KEY }}
-          STACK_YAML: ../stack-lts-12.26.yaml
+          STACK_YAML: ../stack-lts-14.27.yaml


### PR DESCRIPTION
Our minimum LTS is now different. Some day I will not forget this step.
